### PR TITLE
C-KERMIT 10.0 DEVELOPMENT

### DIFF
--- a/NOTES.TXT
+++ b/NOTES.TXT
@@ -15,62 +15,470 @@ http://kermitproject.org/ckupdates.html
      * [12]About
      * [13]Archive
 
-   <-(Use Google Translate to see an approximate translation into another
-   relevant language)
+C-KERMIT UPDATE HISTORY
 
-   Current released version:      [14]9.0.302        20 August 2011
-   Current development version:   9.0.305 Alpha.07   24 January 2022
+      Versions 9.0-10.0: 2011-2022
 
-   [15] DOWNLOAD DEVELOPMENT VERSION      [16] SEE TABLE OF RECENT
+   Current development version:   10.0 Beta.01   07 April 2022   (NOT
+   UPLOADED YET -- THIS PAGE IS A PREVIEW)
+   Current released version:   [14]9.0.302   20 August 2011
+
+   [15] DOWNLOAD THE DEVELOPMENT VERSION      [16] SEE TABLE OF RECENT
    DEVELOPMENT BUILDS
-
-C-KERMIT CHANGE LOG
-
    Changes since version 8.0.207 1 January 2003
    Now in reverse chronological order (newest first)
 
      [17]Frank da Cruz
      [18]The Kermit Project, Bronx NY.
-     Last update: Wed Jan 26 08:47:11 2022 New York time
+     Last update: Mon May 16 07:48:21 2022 New York time
 
    Also see:
      * [19]Change logs for C-Kermit releases 1985-2011  (plain text)
      * [20]Announcements of older C-Kermit releases  (plain text)
 
-   These are the changes to C-Kermit since [21]Kermit 95 was last released
-   as version 2.1.3 on January 1, 2003, and therefore also the changes
-   that would appear in any [22]new release of Kermit 95. This file, which
-   as of October 2021 is about 14,000 lines long, was originally a
-   plain-text change log in chronological order (newest entries at the
-   bottom). In May 2017 it was converted to HTML by the Dev.22
-   [23]text-to-html script, and as of 27 July 2020 it has been rearranged
-   so the latest information is at the top and the oldest at the bottom,
-   and the formatting was improved by makeshift scripts and by hand. From
-   now on all changes will be entered directly into this page. As time
-   permits, there might also be further improvements in presentation and
-   reshuffling of sections that might be confusing because of the reversed
-   order.
+   This file, which as of May 2022 would be about 200 pages long if
+   printed, was originally a plain-text change log in chronological order
+   (newest entries at the bottom). In May 2017 it was converted to HTML by
+   a [21]text-to-html Kermit script, and as of 27 July 2020 it has been
+   rearranged so the latest information is at the top and the oldest at
+   the bottom, and the formatting was improved by makeshift scripts and by
+   hand. All changes since July 2020 have been entered directly into this
+   page.
 
-   [[24]See previous (newest-last) version of this page]
+C-Kermit 10.0 Beta.01 16 May 2022  (WORK IN PROGRESS - NOT YET UPLOADED)
 
-   NOTE: During (and for decades prior to) the C-Kermit 9.0 development
-   cycle in 2010-2011, I had direct access to over [25]200 platforms for
-   development and test builds. Now I have access to exactly three:
-   NetBSD, Red Hat Linux, and Ubuntu Linux. Before a proper new C-Kermit
-   release can be made, I'll need help from users of the other Linux
-   distributions, and of Mac OS X, FreeBSD, OpenBSD, and whatever other
-   Unix varieties are still viable in 2020, as well OpenSSL and Kerberos
-   (especially Heimdal) programmers if those security methods are to be
-   carried forward.
+   [[22]What's new in C-Kermit 10.0]  [[23]Changes since Alpha.07]
 
-   NOTE 2: I have an infinitely long To-Do list for C-Kermit but I think
-   it's a good idea to release 9.0.305 in its present form ASAP, simply
-   because the last formal release (9.0.302) fails to build on so many
-   platforms where it was perfectly OK ten years ago, due to changes in
-   the underlying APIs, shuffling around of header files on different
-   platforms and OS distributions, and changes in the C language itself.
-   Unix and C badly need a "stability layer" to keep programs working over
-   the long haul.
+   The forthcoming new release of C-Kermit, expected "pretty soon" will be
+   called 10.0 rather than 9.0.305, not so much because it's radically
+   different from 9.0, but because (a) it's been over 10 years the
+   previous release and (b) it'll be my final release. Afterwards it can
+   be further developed (or not) by the public via Github or whatever
+   other collaborative development methods supplant it. Meanwhile the
+   previous test release, 9.0.305 Alpha.07, has proven to be [24]quite
+   stable. The new release should function normally on most modern Unix
+   variations (and hopefully older ones as well), and also on VMS versions
+   5.4 through 8.4. I realize there are some as-yet unresolved issues on
+   Solaris but there's nothing I can do about them without access.
+
+   WHY NOW?:
+          I have an infinitely long To-Do list for C-Kermit but I think
+          it's a good idea to release this version ASAP, simply because
+          the last formal release (9.0.302) fails to build on so many
+          platforms where it was perfectly OK eleven years ago, due to
+          changes in the underlying APIs, shuffling around of header files
+          on different platforms and OS distributions, and changes in the
+          C language and/or compilers. In fact, previous releases WILL NOT
+          BUILD on most modern Linuxes due to a backwards-incompatible
+          change in glibc. And even when they do produce an executable, it
+          is only after issuing reams of warnings about constructions that
+          used to be perfectly legal. Unix and C badly need a "stability
+          layer" to keep programs working over the long term.
+
+   ABOUT TEST BUILDS:
+          During (and for decades prior to) the C-Kermit 9.0 development
+          cycle in 2010-2011, I had direct access to over [25]200
+          different Unix platforms for development and test builds, not to
+          mention the other OS families. Now I have access to exactly
+          three: NetBSD, Red Hat Linux, and Ubuntu Linux. Before a proper
+          new C-Kermit release can be made, I'll need help from users of
+          the other Linux distributions, and of Mac OS X, FreeBSD,
+          OpenBSD, Minix, Android, and whatever other Unix varieties are
+          still viable in the 2020s, plus (Open)VMS, as well OpenSSL and
+          Kerberos (especially Heimdal) programmers if those security
+          methods are to be carried forward.
+
+   THE C-KERMIT MAKEFILE:
+          The makefile has evolved from a single target (4.2BSD) in 1985
+          into a nearly 9000-line monster with (at this writing) over 750
+          targets. I haven't made any effort to "clean it up". The world
+          is a big place, and who can say that there aren't still people
+          out there somewhere running ancient versions of UNIX who might
+          need a newer release of C-Kermit. Anyway it's like a Unix
+          history museum. As is C-Kermit itself, with code to support all
+          those ancient OS's: Bell Labs Unix V7, AT&T SVR3, 2.9BSD
+          (16-bit!), Cray X/MP, DG/UX, DEC Ultrix, OSF/1, Venix, IX/370,
+          NeXTstep, QNX, Xenix, DYNIX, SINIX, IRIX...
+
+   ABOUT KERMIT 95:
+          Almost all the changes noted in this document were made after
+          the still-current release of [26]Kermit 95 for Windows, 2.1.3 of
+          1 January 2011, which is based on C-Kermit; in fact it is the
+          Windows version of C-Kermit, similar the Unix version and VMS
+          version. Thus all the fixes and improvements described here are
+          missing from K95 2.1.3 of 1 January 2011, but will magically
+          appear in [27]any new release based upon the current C-Kermit
+          source code.
+
+C-Kermit 10.0 Beta.01 changes since Alpha.07
+
+   Aside from the new version number, the changes since Alpha.07 are
+   modest.
+
+|> New features
+
+     * Serial-port speed selections for 1000000, 2000000, 2500000,
+       3000000, 3500000, and 4000000 bps, suggested by Pali Rohár. The new
+       high speeds have not been tested because I no longer have a
+       computer with serial port.
+     * New VDIRECTORY command with 1-letter synonym V, a convenient alias
+       for the DIRECTORY command (and a familiar one to old DEC-20 hands).
+     * New HELP COMPACT-SUBSTRING command to show the syntax for the
+       compact substring notation that was added in C-Kermit 9.0.300.
+     * HELP text improved for GREP, TRANSLATE, TOUCH /MODTIME, FREAD
+       /TRIM, FUNCTION DIRECTORIES, FUNCTION FILEINFO.
+     * New -DNODEPRECATED parameter for makefile KFLAGS to disinclude FTP,
+       Telnet, and RLOGIN clients plus WTMP logging, all "deprecated" now.
+       This saves only about 200K in the executable size.
+     * New Makefile targets: New "list" target to list all targets and
+       "count" target to show how many targets there are.
+
+|> Bugs fixed
+
+     * ckufio.c: Bug fixed affecting -DNOUUCP builds (such as Mac OS) when
+       receiving a file in which C-Kermit created a bogus empty backup
+       file (e.g. bug.txt.~1~). Reported and diagnosed by MacPorts port
+       maintainer Lin Dongyu.
+     * ckcfns.c, ckcfn2.c, ckcfn3.c, ckcpro.w: SET SEND PACKET-LENGTH
+       applied to all packets when it should have applied only to Data
+       packets, now it does [28]details here.
+     * ckuus3.c: Bug fixed in S-Expression parser; "if (xx = 0)" should
+       have been "if (xx == 0)" (did you know that C-Kermit had a
+       [29]mini-LISP iterpreter built in?...  [30]What day is Easter in
+       2033?)
+     * ckcfns.c: The 'debug(F110,"sipkt rp","",rp);' statement in sipkt()
+       had a bad argument list all these years.
+     * Extraneous line in "help function tablelook" removed.
+     * SET HOST command switch /TIMEOUT: was removed because the
+       supporting code was never written.
+     * Top-level DEBUG command that was added in C-Kermit 9.0 was removed
+       because it never did anything and there was no help text for it.
+
+|> Compiler warnings hushed
+
+   ... most of them issued only by the very picky Mac OS Clang compiler:
+     * ckcftp.c: changed a long if-else-if.. (dangling else) sequence to a
+       switch
+     * ckctel.c: changed:
+tn_ssbopt(TELOPT_NEWENVIRON,TELQUAL_SEND,request,
+        strlen(request));
+
+           to:
+tn_ssbopt(TELOPT_NEWENVIRON,TELQUAL_SEND,(CHAR *)request,
+        strlen((CHAR *)request)); /* 2022-01-27 */
+
+       in hopes of silencing some "Pointers are not assignment-compatible"
+       and "Argument #1 is not the correct type" warnings on a platform I
+       don't have access to (HP-UX).
+
+     * ckcpro.w: fixed 1 dangling else
+     * ckuusr.c: fixed 7 dangling elses
+     * ckuus2.c: fixed 1 dangling else
+     * ckuus3.c: fixed 10 dangling elses
+     * ckuus4.c: fixed 67 dangling elses
+     * ckuus5.c: fixed 1 dangling else
+     * ckuus6.c: fixed 1 dangling else
+     * ckuus7.c: fixed 1 dangling else
+     * ckuusx.c: Fixed several dummy ck_curpos() declarations to suppress
+       warnings.
+     * ckuusx.c: fixed 2 extraneous parentheses and 1 dangling else
+     * ckcfn2.c: fixed 1 dangling else
+     * ckutio.c: fixed 1 dangling else
+     * makefile: added -Wdeprecated-declarations to macos target (for
+       logwtmp)
+
+   "Dangling else" is (or was) perfectly legal when used correctly; the C
+   language was originally designed for use by people who knew what they
+   were doing and was thoroughly documented by its authors, Kernighan and
+   Plauger, in a book (two really: original C and ANSI C). It makes no
+   sense to keep changing this or any other programming language out from
+   under all the millions of programs that have already been written in
+   it.
+
+C-Kermit 10.0: Brief summary of new features since 9.0.302
+
+     * An [31]essential adaptation to a change in Glibc 2.28 that broke
+       C-Kermit and caused several major Linux distributions to drop it.
+     * SET SPEED 1000000, 1500000, 2000000, 2500000, 3000000, 3500000, and
+       4000000 for high serial-port speeds on platforms that support them.
+     * Numerous updates for VMS/OpenVMS operating systems from 5.4 to 8.4,
+       so it is not orphaned.
+     * Adaptation to Android ([32]note) ([33]build)
+     * [34]Unix only: New ability to run Kermit scripts in a pipeline, and
+       to otherwise behave as a typical stdin/stdout/stderr program
+       (example: the [35]html script).
+     * New [36]CHANGE command for changing strings in external files. Like
+       when you have a website with hundreds of pages in a whole directory
+       tree that link to another website whose URL changed.
+     * Unix makefile: new target make linux-nodeprecated to build C-Kermit
+       without "deprecated" features such as FTP, Telnet, Rlogin, Wtmp
+       logging, and ([37]explained below) arrow-key support.
+     * And... the [38]guts of the command processor were almost totally
+       rewritten to allow IF-command and function arguments to be entered
+       in a natural way. Sounds scary but I tested the result by using it
+       heavily over 17 months.
+
+   Other changes:
+     * TOUCH /MODTIME:xxx, like the Unix 'touch' command, sets a file's
+       date. Works on single files, multiple files, and directory trees;
+       many selection criteria are available.
+     * Locale support for date formats, day and month names, system error
+       messages, currency notaion, sorting and collation behavior, etc,
+       plus the new functions \fdayname() and \fmonthname() that return
+       the full name of the given day or month in the locale's language:
+       [39]locale.html, [40]remind.html.
+     * New variables: \v(year) = current year, \v(month) = current month
+       (three letters), and \v(nmonth) = current month (numeric) to
+       complete the set that already included \v(date), \v(day), and
+       \v(nday), with \v(date), \v(day), and \v(month) rendered according
+       to locale.
+     * New IF conditions: NEQ, LLE, LGE, BINARY, TEXT.
+     * Parsing of some REMOTE commands were broken, now fixed.
+     * New (ECHO xxx) command for use within [41]LISP S-expressions.
+     * New \ffileinfo() function to get all the information available
+       about a given file, used by the [42]Photogallery script.
+     * DIRECTORY /BRIEF /EXCEPT:xxx fixed (required for [43]Photogallery),
+       e.g. "dir /brief /except:*-[tr].jpg /output:IMAGES *.jpg"
+     * New \ffilecompare() function (tells whether two files are identical
+       or differ, used in the [44]renamejpgs script).
+     * Some new date formats for \fcvtdate(): [45]photogallery.html,
+       [46]remind.html.
+     * In response to Unix full path names getting longer and longer all
+       the time: Improved fullscreen file-transfer display to show user's
+       login directory as ~/ and to truncate too-long lines from the left
+       rather than the right.
+     * The current directory shown in C-Kermit's default prompt now also
+       uses ~/ notation to save space.
+     * Numerous code changes to integrate with [47]Kermit 95 source, a
+       project that was active in 2013 but never completed. If you would
+       like to have C-Kermit for Windows (previously known as Kermit 95 =
+       K95) and you are a Windows programmer please ([48]CLICK HERE) to
+       see how you can help.
+     * Numerous adaptations to newer OpenSSL versions, but more work is
+       needed if anyone is actually going to make SSL connections with
+       C-Kermit.
+     * Countless fixes and adaptations to newer Unix platforms, libraries,
+       and C compilers. Described below from [49]HERE to [50]HERE... about
+       2000 lines of text. And also in the [51]abbreviated edit history
+       found in the no-longer-appropriately named [52]C-Kermit Daily
+       Source Archive page. This type of pointless busy work will never
+       end.
+
+   Reminder: details of each built-in function are shown by C-Kermit's
+   HELP FUNCTION name command, e.g. "help function cvtdate" (or more
+   briefly, "h fun cvtd").
+
+Pending issues
+
+   Glibc conflicts
+          C-Kermit has to multiplex simultaneous keyboard and
+          communications i/o. The code for this has evolved over nearly 40
+          years at this writing and it's rather complex. A big goal from
+          the beginning was efficiency because in the early days Kermit
+          might have been running on a very slow computer. Thus C-Kermit
+          uses the buffered fopen()/getc() interface for less context
+          switching than the bare metal open()/read() interface for each
+          character. Kermit's approach was fine until I added support for
+          arrow keys in version 8.0. Arrow keys are different from regular
+          keys in that they generate multiple bytes instead of a single
+          byte. So when there is a keyboard event Kermit has to peek ahead
+          in the keyboard buffer to tell the difference, and if it's an
+          arrow key, then Kermit "does something" rather than just
+          transmitting the byte sequence, e.g. recalls the previous
+          command. So far so good. But the API for peeking ahead is
+          apparently offensive to the glibc people, and they are intent on
+          removing it. The first step took place in 2021 and the result
+          was that C-Kermit failed to compile. A workaround was found that
+          fixed the problem, but the Gnu people don't approve of it and
+          are determined to remove all possible ways of "poking around in
+          stdio internals on *any* platform". They say that they will
+          "consider" adding "musl-compatible __freadahead", whatever that
+          is, maybe before they pull the plug on the current setup, maybe
+          not. So the day will come when C-Kermit breaks again and then
+          there will be four possibilities:
+
+         1. Give up on arrow keys and rebuild C-Kermit with -DNOARROWKEYS
+            (anybody can do this);
+         2. Change thousands of lines of code to do single-byte instead of
+            buffered reads as the Gnu people suggest;
+         3. Take advantage of the new __readahead thing if it's
+            appropriate but this won't be portable to older Linux
+            versions;
+         4. The Linux application packagers drop C-Kermit again.
+
+          In the great scheme of things maybe arrow keys aren't so
+          important, but who really knows? And then what happens when they
+          change something else? The Gnu folks have a very narrow view.
+          C-Kermit is not just a Linux program; in fact it predates Linux
+          by six years. C-Kermit is portable among at least [53]nine
+          different operating system families and at least [54]190
+          different Unix varieties, the vast majority of which do not have
+          Glibc. How can a total rewrite of C-Kermit's terminal i/o be
+          tested on all those platforms? C-Kermit's code has been
+          painfully, scrupulously designed to be portable among all those
+          platforms. Most of them might be "legacy" now but that does not
+          mean that they don't still exist and that people and companies
+          and schools and government agencies don't depend on them for
+          vital functions.
+
+          In my view it is a CRIME to change an API for any reason when
+          unknown numbers of programs depend on it, and unknown numbers of
+          people depend on those programs. The entire world increasingly
+          depends on software written in C for Unix, and particularly
+          Linux. The absolute TOP priority for any new release of Linux or
+          C or its libraries must be to preserve backwards compatibility
+          so existing programs continue to compile, link, and work. This
+          was the situation back in the days when software (including
+          compilers) was mainly written by paid professionals who were
+          responsible to -- and in touch with! -- their users. Today's
+          Wild West software culture is not a improvement. Meanwhile I
+          added a new target to the makefile:
+
+make linux-nodeprecated
+
+          do eliminate everything that has been deprecated (directly or
+          indirectly) up to now: FTP, Telnet, Rlogin, Wtmp logging, and
+          arrow-key support. I'm sure I must have missed a few; they can
+          be added at the top of the ckcdeb.h file.
+
+   Security methods
+          For the major surviving Unix-based operating systems such as
+          Linux, *BSD, and Mac OS, the main default makefile targets (e.g.
+          "make linux") do NOT include any security features such as SSL
+          or Kerberos and never have. Separate targets are provided for
+          the desired kind of security code, e.g. "make linux+ssl", "make
+          linux+krb5", "make linux+krb5+ssl". But C-Kermit's interfaces to
+          OpenSSL, Kerberos, etc, are not necessarily up to date or even
+          functional. SSL and Kerberos programmers are welcome to make
+          fixes and I will incorporate them into subsequent 10.0 Betas. As
+          of 10.0 Beta.01 these builds work on certain platforms but not
+          on others, depending mainly on which SSL and Kerberos versions
+          are installed on the host. Summary:
+
+          + Kerberos IV and V support in Kermit should be up to date and
+            solid, but many sites have switched from MIT Kerberos to
+            Heimdal, which Kermit doesn't support, in which case builds
+            such as "make linux+krb5" fail (some Heimdal code is present
+            but evidently not enough).
+          + Some adaptations to newer OpenSSL versions have been made but
+            the target is moving too fast to keep up, and most builds such
+            as "make linux+ssl" either fail or get tons of warnings.
+          + Telnet and FTP servers secured by OpenSSL or Kerberos have
+            vanished, and these were the whole reason that C-Kermit
+            included these security methods.
+          + The SSL and Kerberos code is still included in the source code
+            if anybody cares to bring them up to date, presumably and
+            preferably in a backwards-compatible way, so C-Kermit could be
+            built with (e.g.) any version of OpenSSL, not just the latest
+            one.
+
+   WTMP log
+          Apparently WTMP logging was "deprecated" at some point after
+          C-Kermit 9.0 was released, resulting in "deprecated" warnings in
+          ckufio.c on some or all Unix-based OS's. WTMP logging is (was)
+          done when C-Kermit is running as a [55]Kermit Internet Service
+          Daemon (IKSD, similar to an FTP server but better) to log the
+          sessions it hosted. Presumably WTMP will disappear some day and
+          then C-Kermit builds will get fatal errors and compile time or
+          link time. Kermit can be built without IKSD (and WTMP) by
+          including -DNOIKSD in the KFLAGS. It can be built with IKSD but
+          without WTMP via -DNOWTMP.
+
+   Internet Kermit Service Daemon
+          IKSD was secured by Kerberos or OpenSSL or any of C-Kermit's
+          other built-in security methods, but since all of those are now
+          in limbo, at least in terms of C-Kermit's interface to them,
+          IKSD is no longer very useful. Still, it was a good idea and an
+          even better one now in light of the retirement of FTP service.
+          It could be revived using the external ssh client on the end
+          that makes the connection (e.g. "ssh somehost.org 1649"), and an
+          ssh server on TCP port 1649 that starts C-Kermit with the
+          [56]appropriate command-line options and with its stdin/out/err
+          redirected to the ssh connection.
+
+   Terminal emulation
+          C-Kermit does not do terminal emulation. It simply writes
+          incoming meterial to the screen, and passes your keystrokes
+          along to the other computer. Terminal emulation is provided by
+          the window in which C-Kermit is running. Normally this is not an
+          issue, but one very handy feature that other terminal emulators
+          (such as Kermit 95) have but C-Kermit lacks is key mapping ,
+          where you can assign any key or key combination (e.g. Alt-h,
+          Ctrl-Alt-Shift-q, F1, Insert, etc) to send (or do) whatever you
+          want. C-Kermit can't do that because it doesn't know what keys
+          you actually pressed because either (a) your keyboard is
+          connected to a different computer than the one where C-Kermit is
+          running, or (b) there is no reliable and portable Unix API for
+          obtaining key events and scan codes. C-Kermit does, however,
+          have a SET KEY command, but it works only with ASCII keys.
+
+          Unlike all the other C-Kermit versions (Unix, VMS, etc) C-Kermit
+          for Windows -- previously known as Kermit 95 or simply K95 --
+          does do terminal emulation because it is running on the same
+          computer your keyboard and screen are connected to, so it can
+          capture keycodes and write to video. Let's hope C-Kermit for
+          Windows (CKW) can be released some day soon; if you're a Windows
+          C programmer and would like to help out, [57]CLICK HERE.
+
+   Error messages
+          C-Kermit's runtime error messages, especially those emanating
+          from scripts, are particularly uninformative, as is the
+          \v(lastcommand) variable. It's because some commands are
+          executed by internally-defined macros composed of multiple
+          commands, calling each other recursively. Also, a large chunk of
+          code surrounded by { ... } in a script looks like a single
+          command to the parser.
+
+   Text blocks
+          There has never been an intuitive way of assigning a multiline
+          text block as the value of a macro. For example:
+
+define sometext {
+This is some text.
+This is the second line.
+
+The line above is empty.
+  This line is indented.
+This line is not.
+}
+
+          "echo \m(sometext)" shows leading and interline spaces
+          eliminated, and the lines themselves are gathered into a single
+          comma-separated-list. A whole new data structure would be
+          required to accommodate multiline text blocks.
+
+   Variable evaluation
+          For historical reasons all \%x variables and \&x[] arrays are
+          evaluated recursively. This is almost never desired and can
+          wreak havoc when a value is a DOS or Windows pathname in which
+          the directory separator is backslash. A "[58]set
+          variable-evaluation" command was added in C-Kermit 9.0, with
+          choices "recursive" (default) and "simple". The default can
+          never be changed to "simple" because that could break countless
+          scripts that actually take advantage of the original evaluation
+          method. But if you are writing a script with no intention of
+          recursing and want to avoid having your \%x and \&x[] variable
+          values garbled, put:
+
+     if >= \v(version) 900000 set variable-evaluation simple
+
+          at the beginning of the script. That way if your script is
+          processing external data that happens to contain any
+          backslashes, nothing bad will happen. But if someone executes
+          the same script with C-Kermit 8.0 or earlier the risk is still
+          there. Of course your script could print a warning, or even
+          require an appropriate C-Kermit version. Meanwhile even with
+          recursion disabled globally you can still force recursion when
+          needed with the \frecurse() function:
+
+\frecurse(s1)
+ s1 = name of \&x or \&x[] type variable
+Returns the result of evaluating the variable recursively.
+
+   Minor bugs
+          TOUCH /MODTIME:datetime does not accept all different date-time
+          formats, only numeric yyyy:mm:dd:hh:mm:ss or yyyy:mm:dd. The
+          HELP TOUCH text was updated to say this.
 
 C-Kermit 9.0.305 Alpha.07 24 January 2022
 
@@ -229,7 +637,7 @@ static char * tags[] = { "_whi", "_for", "_sw_", "_if_" };
 
 C-Kermit 9.0.305 Alpha.05 14 November 2021
 
-   As of December 6, 2021, 56 builds are listed in [26]this table; 48 of
+   As of December 6, 2021, 56 builds are listed in [59]this table; 48 of
    them successful, 8 of them failed.
 
      * 16 Nov 2021:
@@ -359,7 +767,7 @@ C-Kermit 9.0.305 Alpha.05 14 November 2021
             95 for MS Windows and IBM OS/2 and didn't change it because
             OS/2-specific modules probably still use MAXPATHLEN rather
             than CKMAXPATH but we can deal with that if ever
-            [27]development on K95 resumes. Also, two references to
+            [60]development on K95 resumes. Also, two references to
             MAXPATHLEN around line 10420 were changed to CKMAXPATH. A
             misplaced #endif matching #ifndef VMS at line 13942 was moved
             two statements down, where it should have been.
@@ -405,9 +813,9 @@ def MAXPATHLEN 1024
        should have.
        So now C-Kermit has been changed to apply the SEND PACKET-LENGTH
        setting only to outbound file Data packets. This is a rather
-       fundamental change that, in a sense, has an impact the definition
-       of the protocol if only by making explicit the difference between
-       administrative and data packets.
+       fundamental change that, in a sense, has an impact on the
+       definition of the protocol if only by making explicit the
+       difference between administrative and data packets.
        The feature negotiation packets are about 30 characters (bytes)
        long and have never presented a problem. However, a filename can be
        any length at all. If it is longer than about 90 characters, it can
@@ -420,8 +828,8 @@ def MAXPATHLEN 1024
        practice because filenames are rarely that long.
        But the story doesn't stop there because the file receiver can (but
        is not required to) send the name under which it stores the
-       incoming file, often including the path, so the user knows exactly
-       how to find it on the receiving computer. This might be
+       incoming file, perhaps including the path, so the user knows
+       exactly how to find it on the receiving computer. This might be
        considerably longer than the original if it includes a path, such
        as:
        /net/w/0/htdocs/fdc/kermitproject/ftp/kermit/archives/
@@ -561,8 +969,6 @@ C-Kermit 9.0.305 Alpha.03  (THIS ONE WASN'T UPLOADED)
 
 C-Kermit 9.0.305 Alpha.02 19 September 2020
 
-   [[28]DOWNLOAD]
-
    From Sébastien Villemot (Debian): Remove clauses from the linux+krb5,
    linux+ssl, and linux+krb5+ssl makefile targets that tested to see if an
    executable was actually created, because they violate Debian policy.
@@ -590,7 +996,7 @@ C-Kermit 9.0.305 Alpha.02 19 September 2020
     4. Same thing for dbuf[] in function domydir(). ckuus6.c, 18 Sep 2020.
     5. Complaints about implicit definitions of tgetent(), tgetstr(),
        tputs(), and tgoto() in the curses-related routines fxdinit(),
-       ck_termset(), ck_curpos(). [29]See notes below. I had the
+       ck_termset(), ck_curpos(). [61]See notes below. I had the
        prototypes commented out because they caused problems on some
        platforms. Uncommenting causes disaster on Red Hat, NetBSD, etc. I
        had to add a clause to the linux target that looks in /etc/issue
@@ -662,7 +1068,7 @@ C-Kermit 9.0.305 Alpha.02 19 September 2020
    Date: 24 Jul 2020.
    Results:
 
-   Platform No security OpenSSL Keberos 5
+   Platform No security OpenSSL Kerberos 5
    Red Hat Linux 6.1 / OpenSSL 1.0.1e OK (no warnings) OK (no warnings)
    (libs not installed)
    NetBSD 9.0 / OpenSSL 1.1.1d OK (no warnings) Fails (many warnings)
@@ -758,7 +1164,7 @@ if \findex(\m(notrated),\m(line)) {
    But there is nothing Kermit can do about this; even if I could figure
    out how to find the Orientation tag, what would I do with it?
    Eventually it dawned on me that the right place to handle this (to fix
-   the problem when it occurs in the [30]Photogallery script) was on the
+   the problem when it occurs in the [62]Photogallery script) was on the
    Imagemagick command line. Simply adding -auto-orient did the trick.
    Photogallery 2.14, 21 Jul 2017. No changes to Kermit. But if there were
    an EXIF library for Unix...
@@ -1510,9 +1916,9 @@ Dev.10
    sparc. makefile, 23 Feb 2014.
 
    Documentation for MULTIARCH:
-   [31]https://wiki.debian.org/Multiarch/Implementation
-   [32]https://wiki.ubuntu.com/MultiarchSpec
-   [33]https://wiki.debian.org/Multiarch/HOWTO
+   [63]https://wiki.debian.org/Multiarch/Implementation
+   [64]https://wiki.ubuntu.com/MultiarchSpec
+   [65]https://wiki.debian.org/Multiarch/HOWTO
 
    From my to-do list.... I noticed a while back that \fsplit(s,&a,,TSV)
    could mess up if the data fields contained grouping characters like
@@ -2110,7 +2516,7 @@ Dev.03
    13 Mar 2013.
 
    A large manufacturing company upgraded from MS-DOS Kermit to Kermit 95
-   because new PCs were installed that could no longer us MS-DOS Kermit.
+   because new PCs were installed that could no longer use MS-DOS Kermit.
    These PCs are used to control Cincinnati (now MAG IAS) machines (press
    brakes, composite tape layers, etc), which use their own implementation
    of Kermit protocol to exchange data with the PC. Where MS-DOS Kermit
@@ -2235,7 +2641,7 @@ SET SEND TIMEOUT 20 FIXED
    Vanity herald for Android: ckuver.h, 20 Jul 2012.
 
    From Tim Sneddon:
-   [34]http://tim.sneddon.id.au/blog/Posts/C-Kermit_for_Android -
+   [66]http://tim.sneddon.id.au/blog/Posts/C-Kermit_for_Android -
    Adaptation of C-Kermit to Android via the Linux path; required very few
    changes, mainly #ifdef'ing a couple Linux APIs not supported in
    Android. ckcdeb.h, ckufio.c, ckutio.c, 20 Jul 2012.
@@ -3002,10 +3408,10 @@ Alpha.07
    From Lewis McCarthy:
   Based on code inspection, C-Kermit appears to have an SSL-related security
   vulnerability analogous to that identified as CVE-2009-3767 (see e.g.
-   [35]http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3767).
+   [67]http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3767).
 
   I'm attaching a patch for this issue relative to the revision of ck_ssl.c
-  obtained from a copy of  [36]http://www.columbia.edu/kermit/ftp/test/tar/x.zip
+  obtained from a copy of  [68]http://www.columbia.edu/kermit/ftp/test/tar/x.zip
   downloaded on 2010/07/30, which I believe is the latest.
 
   When this flaw was first widely publicized at last year's Black Hat
@@ -3013,8 +3419,8 @@ Alpha.07
   indeed issued certificates that could be used to exploit this class of
   vulnerability. As far as I know they have not revealed specifically which
   public CA(s) had been found issuing such certificates.
-  Some references:  [37]http://www.mseclab.com/?p=180
-   [38]http://www.theregister.co.uk/2009/07/30/universal_ssl_certificate/
+  Some references:  [69]http://www.mseclab.com/?p=180
+   [70]http://www.theregister.co.uk/2009/07/30/universal_ssl_certificate/
 
    Patches added to ck_ssl.c, 4 Aug 2010.
 
@@ -3937,7 +4343,7 @@ In file included from ckutio.c:15674:
 make solaris9+openssl "SSLINC=-I/opt/openssl-0.9.8k/include" \
    "SSLLIB=-L/opt/openssl-0.9.8k/lib"
 
-   makefile, [39]http://kermit.columbia.edu/security.html, 25 Sep 2009.
+   makefile, [71]http://kermit.columbia.edu/security.html, 25 Sep 2009.
 
    Added or fixed some missing prototypes in ckctel.h:
    fwdx_send_xauth_to_xserver(), fwdx_parse_displayname. 25 Sep 2009.
@@ -5229,7 +5635,7 @@ sz: cannot open finished.: No such file or directory
    Kermit always does at least some minimal encoding of C0/C1 control
    characters such NUL and DEL and IAC, and I doubt that Zmodem does.
 
-   [40]http://zssh.sourceforge.net/ says:
+   [72]http://zssh.sourceforge.net/ says:
 
    If file transfer is initiated but never completes, e.g. a line like:
 Bytes Sent:      0/    513   BPS:0        ETA 00:00  Retry 0: Got ZCAN
@@ -9600,10 +10006,10 @@ xx one two three four
    soon, but let's get a good stable 8.0.211 release out first! Meanwhile,
    for future reference, here are a few articles:
 
- General:  [41]http://freshmeat.net/articles/view/709/
- Linux:    [42]http://www.ece.utexas.edu/~luo/linux_lfs.html
- HP-UX:    [43]http://devrsrc1.external.hp.com/STK/partner/lg_files.pdf
- Solaris:  [44]http://wwws.sun.com/software/whitepapers/wp-largefiles/largefiles
+ General:  [73]http://freshmeat.net/articles/view/709/
+ Linux:    [74]http://www.ece.utexas.edu/~luo/linux_lfs.html
+ HP-UX:    [75]http://devrsrc1.external.hp.com/STK/partner/lg_files.pdf
+ Solaris:  [76]http://wwws.sun.com/software/whitepapers/wp-largefiles/largefiles
 .pdf
 
    From Jeff, 14 Mar 2004:
@@ -10126,7 +10532,7 @@ xx one two three four
    Unix, VMS, WIndows, and OS/2.
 
    The FTP file facts fix came from first exposure to the new OpenBSD FTP
-   server: [45]ftp://ftp7.usa.openbsd.org/pub/os/OpenBSD/3.3/i386/ The
+   server: [77]ftp://ftp7.usa.openbsd.org/pub/os/OpenBSD/3.3/i386/ The
    period in "UNIX.mode" caused an erroneous word break, adding junk to
    the filename.
 
@@ -10546,12 +10952,10 @@ while ((n--) && xx_inc(2) >= 0) ;
    ---------------------------------
    **************************
 
-   [[46]Go to top]
+   [[78]Go to top]
      __________________________________________________________________
 
-
-    ckupdates.html: 20200131 11:26:59 ... Text to html by Kermit [47]html
-    script 3.03
+   Updates to C-Kermit, versions 8.0, 9.0, and 10.0
 
 References
 
@@ -10575,30 +10979,61 @@ References
   18. http://kermitproject.org/
   19. https://kermitproject.org/ftp/kermit/changelogs/
   20. https://kermitproject.org/ftp/kermit/ckermit/
-  21. file:///net/u/1/f/fdc/web/k95.html
-  22. file:///net/u/1/f/fdc/web/k95sourcecode.html
-  23. http://www.kermitproject.org/html.html
-  24. file:///net/u/1/f/fdc/web/ckupdates-90305-alpha1.html
+  21. file:///net/u/1/f/fdc/web/html.html
+  22. file:///net/u/1/f/fdc/web/ckupdates.html#ck10summary
+  23. file:///net/u/1/f/fdc/web/ckupdates.html#ck10changes
+  24. file:///net/u/1/f/fdc/web/ck90305table.html#table
   25. file:///net/u/1/f/fdc/web/ck90tables.html
-  26. https://www.kermitproject.org/ck90305table.html
+  26. file:///net/u/1/f/fdc/web/k95.html
   27. file:///net/u/1/f/fdc/web/k95sourcecode.html
-  28. file:///net/u/1/f/fdc/web/ckdaily.html
-  29. file:///net/u/1/f/fdc/web/ckupdates.html#tgetent
-  30. file:///net/u/1/f/fdc/web/photogallery.html
-  31. https://wiki.debian.org/Multiarch/Implementation
-  32. https://wiki.ubuntu.com/MultiarchSpec
-  33. https://wiki.debian.org/Multiarch/HOWTO
-  34. http://tim.sneddon.id.au/blog/Posts/C-Kermit_for_Android
-  35. http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3767)
-  36. http://www.columbia.edu/kermit/ftp/test/tar/x.zip
-  37. http://www.mseclab.com/?p=180
-  38. http://www.theregister.co.uk/2009/07/30/universal_ssl_certificate/
-  39. http://kermit.columbia.edu/security.html
-  40. http://zssh.sourceforge.net/
-  41. http://freshmeat.net/articles/view/709/
-  42. http://www.ece.utexas.edu/~luo/linux_lfs.html
-  43. http://devrsrc1.external.hp.com/STK/partner/lg_files.pdf
-  44. http://wwws.sun.com/software/whitepapers/wp-largefiles/largefiles.pdf
-  45. ftp://ftp7.usa.openbsd.org/pub/os/OpenBSD/3.3/i386/
-  46. file:///net/u/1/f/fdc/web/ckupdates.html#top
-  47. http://kermitproject.org/html.html
+  28. file:///net/u/1/f/fdc/web/ckupdates.html#sendpacketlen
+  29. file:///net/u/1/f/fdc/web/ckermit80.html#x9
+  30. https://www.kermitproject.org/ftp/kermit/scripts/easter2
+  31. file:///net/u/1/f/fdc/web/ckupdates.html#alpha01
+  32. https://www.kermitproject.org/ftp/kermit/ckermit/android.txt
+  33. https://www.kermitproject.org/ftp/kermit/ckermit/android.mk
+  34. file:///net/u/1/f/fdc/web/unix.html
+  35. file:///net/u/1/f/fdc/web/html.html
+  36. file:///net/u/1/f/fdc/web/change.html
+  37. file:///net/u/1/f/fdc/web/ckupdates.html#pendingissues
+  38. file:///net/u/1/f/fdc/web/ckupdates.html#dev23
+  39. file:///net/u/1/f/fdc/web/locale.html
+  40. file:///net/u/1/f/fdc/web/remind.html
+  41. file:///net/u/1/f/fdc/web/ckermit80.html#x9
+  42. file:///net/u/1/f/fdc/web/photogallery.html
+  43. file:///net/u/1/f/fdc/web/photogallery.html
+  44. https://kermitproject.org/ftp/kermit/scripts/renamejpgs
+  45. file:///net/u/1/f/fdc/web/photogallery.html
+  46. file:///net/u/1/f/fdc/web/remind.html
+  47. file:///net/u/1/f/fdc/web/k95.html
+  48. file:///net/u/1/f/fdc/web/k95sourcecode.html
+  49. file:///net/u/1/f/fdc/web/ckupdates.html#dev24
+  50. file:///net/u/1/f/fdc/web/ckupdates.html#ck90302
+  51. file:///net/u/1/f/fdc/web/ckdaily.html#changelog
+  52. file:///net/u/1/f/fdc/web/ckdaily.html
+  53. file:///net/u/1/f/fdc/web/ck70.html
+  54. file:///net/u/1/f/fdc/web/unix.html
+  55. file:///net/u/1/f/fdc/web/iksd.html
+  56. https://www.kermitproject.org/uiksd.html#x4.1
+  57. file:///net/u/1/f/fdc/web/k95sourcecode.html
+  58. file:///net/u/1/f/fdc/web/ckermit90.html#Vareval
+  59. https://www.kermitproject.org/ck90305table.html
+  60. file:///net/u/1/f/fdc/web/k95sourcecode.html
+  61. file:///net/u/1/f/fdc/web/ckupdates.html#tgetent
+  62. file:///net/u/1/f/fdc/web/photogallery.html
+  63. https://wiki.debian.org/Multiarch/Implementation
+  64. https://wiki.ubuntu.com/MultiarchSpec
+  65. https://wiki.debian.org/Multiarch/HOWTO
+  66. http://tim.sneddon.id.au/blog/Posts/C-Kermit_for_Android
+  67. http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3767)
+  68. http://www.columbia.edu/kermit/ftp/test/tar/x.zip
+  69. http://www.mseclab.com/?p=180
+  70. http://www.theregister.co.uk/2009/07/30/universal_ssl_certificate/
+  71. http://kermit.columbia.edu/security.html
+  72. http://zssh.sourceforge.net/
+  73. http://freshmeat.net/articles/view/709/
+  74. http://www.ece.utexas.edu/~luo/linux_lfs.html
+  75. http://devrsrc1.external.hp.com/STK/partner/lg_files.pdf
+  76. http://wwws.sun.com/software/whitepapers/wp-largefiles/largefiles.pdf
+  77. ftp://ftp7.usa.openbsd.org/pub/os/OpenBSD/3.3/i386/
+  78. file:///net/u/1/f/fdc/web/ckupdates.html#top

--- a/README.TXT
+++ b/README.TXT
@@ -1,21 +1,29 @@
-C-KERMIT 9.0.305 ALPHA TESTING
+C-KERMIT 10.0 DEVELOPMENT
 
-9.0.305 Alpha.07 24 Jan 2022
+For greater detail see https://www.kermitproject.org/ckupdates.html .
 
-We have our first successful build with a REAL (not simulated) pre-ANSI K&R
+C-Kermit 10.0 Beta.01 16 May 2022
+
+Alpha.07 in its basic configuration (e.g. no Kerberos or SSL support) seems
+to have been OK on every platform tested, aside from the ever-increasing
+assortment of picky-compiler warnings.  So after some polishing-up and a
+major version-number promotion, we have the first Beta test.
+
+C-Kermit 9.0.305 Alpha.07 01 Jan 2022
+
+We have our first successful build with a REAL (not simulated) non-ANSI K&R
 non-optimizing C compiler (HP-UX 11.11 with Bundled compiler).  Built
-successfuly for the first time in a decade with Kerberos 5; this was on Red
-Hat Linux 6.10.  Also the first successful Solaris build.  "make install"
-was failing because some text file were missing in tar/zip archives.
-Numerous picky compiler warnings silenced.
+successfuly for the first time in a decade with MIT Kerberos 5.  This was on
+Red Had Linux 6.10.  "make install" was failing because some text file were
+missing in tar/zip archives.  Numerous picky compiler warnings silenced.
 
-I'm not sure it makes sense to bundle a lot of long plain-text documentation
-files in tar and zip archives: the installation instructions, the "beware"
-files, the configuration options file, the C-Kermit program logic manual,
-sample initialization files, etc.  They are all available as web pages on
-the Kermit website and most of them haven't changed in a long time.
+I'm not sure it makes sense to bundle a lot of long plain-text files in
+tar and zip archives: the edit history, installation instruction, the
+"beware" files, the configuration options file, the C-Kermit program logic
+manual, sample initialization files, etc.  They are all available as web
+pages on the Kermit website and most of them haven't changed in a long time.
 
-9.0.305 Alpha.06 15 Dec 2021
+C-Kermit 9.0.305 Alpha.06 15 Dec 2021
 
 At some point since the last real release of C-Kermit (9.0.302 in 2011) some
 ANSI C constructions snuck into the code so pre-ANSI (e.g. K&R) C compilers
@@ -23,7 +31,7 @@ could no longer build C-Kermit.  This has been fixed in Alpha.06, along with
 numerous picky-compiler warnings.  Vielen Dank to Peter Eichhorn of
 Assyst GmbH, Aschheim-Dornach, Germany, "Herr HP-UX C-Kermit".
 
-9.0.305 Alpha.05 14 Dec 2021
+C-Kermit 9.0.305 Alpha.05 14 Dec 2021
 
 New support for 1,500,000bps serial port speed for platforms that offer
 it.  Numerous adjustments to APIs, header files, and C compilers that
@@ -34,7 +42,7 @@ problem was fixed that occured when transferring any file that contained
 successful builds on modern VMS operating system versions on various
 hardware platforms.
 
-9.0.305 Alpha.04 14 Sep 2020
+C-Kermit 9.0.305 Alpha.04 14 Sep 2020
 
 Improvements for VMS builds; most importantly the source-code Zip file 
 was fixed to include no carriage returns; one or more previous versions
@@ -42,23 +50,24 @@ contained a mix of LF and CRLF format files, which was fatal for VMS.  Also
 included: about nine minor changes to address warnings from the VMS build.
 The Zip file for Alpha.04 was created by Zip 3.0 on NetBSD 9.0.
 
-
-9.0.305 Alpha.03 (not published)
+C-Kermit 9.0.305 Alpha.03 (not published)
 
 Some small changes involving errno, SSL ciphers, some declarations, etc.
 
-9.0.305 Alpha.02 19 Sep 2020
+C-Kermit 9.0.305 Alpha.02 19 Sep 2020
 
 No functional changes since last time, but about 30 compile-time warnings
 that were reported by gcc 9.3.0 on Ubuntu 20.04.1 are fixed.  The result
 compiles without warnings there, and also on OpenBSD 9 and Red Hat 6.1.
 
-9.0.305 Alpha.01 24 Jul 2020
+C-Kermit 9.0.305 Alpha.01 24 Jul 2020
 
 Contains to patch to work around the disappearance of the GNU standard I/O
 library symbol "__FILE_defined" from glibc-based Linux distributions such
 as Debian and Ubuntu.  I was not ready to release a new version of C-Kermit
 yet, but this forces the issue.
+
+............................................................................
 
 C-KERMIT 9.0.304 PRERELEASE TESTING
 

--- a/ckcdeb.h
+++ b/ckcdeb.h
@@ -1,9 +1,9 @@
 /*  C K C D E B . H  */
 
 /*
-Sat Nov 6 11:14:45 2021
+Thu May 12 15:33:45 2022
 
-  For recent additions search below for "2021".
+  For recent additions search below for "2021" and "2022".
 
   NOTE TO CONTRIBUTORS: This file, and all the other C-Kermit files, must be
   compatible with C preprocessors that support only #ifdef, #else, #endif,
@@ -29,10 +29,11 @@ Sat Nov 6 11:14:45 2021
     Columbia University Academic Information Systems, NYC (1974-2011)
     The Kermit Project, Bronx NY (2011-present)
 
-  Copyright (C) 1985, 2020,
+  Copyright (C) 1985, 2022,
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
+    Last update: Thu May 12 15:34:02 2022 (NODEPRECATED)
 */
 
 /*
@@ -45,6 +46,29 @@ Sat Nov 6 11:14:45 2021
 */
 #ifndef CKCDEB_H			/* Don't include me more than once. */
 #define CKCDEB_H
+
+/*
+  Disinclude features that are "deprecated" in 2022;
+  on amd64 this saves about 185K out of 2.48MB, so this is really more
+  about political correctness that saving space.  -fdc 12 May 2022
+*/
+#ifdef NODEPRECATED
+#ifndef NOFTP                           /* No more FTP client */
+#define NOFTP
+#endif  /* NOFTP */
+#ifndef NOTELNET                        /* No more Telnet client */
+#define NOTELNET
+#endif  /* NOTELNET */
+#ifndef NORLOGIN                        /* No more RLOGIN client */
+#define NORLOGIN
+#endif  /* NORLOGIN */
+#ifndef NOWTMP                          /* No more WTMP logging */
+#define NOWTMP
+#endif  /* NOWTMP */
+#ifndef NOARROWKEYS                     /* Arrow keys use a deprecated API */
+#define NOARROWKEYS
+#endif  /* NOARROWKEYS */
+#endif  /* NODEPRECATED */
 
 #ifdef OS2
 #include "ckoker.h"
@@ -101,7 +125,10 @@ Sat Nov 6 11:14:45 2021
 #endif /* ANYSCO */
 #endif /* UNIXWARE */
 
-#ifndef MINIX				/* Minix versions */
+#ifndef MINIX				/* MINIX versions */
+#ifdef MINIX340                         /* TIH 1 Feb 2022 */
+#define MINIX
+#else
 #ifdef MINIX315
 #define MINIX
 #else
@@ -113,6 +140,7 @@ Sat Nov 6 11:14:45 2021
 #endif	/* MINIX2 */
 #endif	/* MINIX3 */
 #endif	/* MINIX315 */
+#endif	/* MINIX340 */
 #endif	/* MINIX */
 
 #ifdef CK_SCO32V4			/* SCO 3.2v4 */

--- a/ckcfn2.c
+++ b/ckcfn2.c
@@ -6,10 +6,11 @@
   Author: Frank da Cruz <fdc@columbia.edu>,
   Columbia University Academic Information Systems, New York City.
 
-  Copyright (C) 1985, 2021,
+  Copyright (C) 1985, 2022,
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
+    Last update: 8 May 2022
 */
 /*
  Note -- if you change this file, please amend the version number and date at
@@ -2870,10 +2871,11 @@ rpack() {
 		}
 		return(j);
 	    }
-	    if (nakstate)		/* j == -1 is a read timeout */
-	      xxscreen(SCR_PT,'T',(long)winlo,"");
-	    else
-	      xxscreen(SCR_PT,'T',(long)pktnum,"");
+	    if (nakstate) {		/* j == -1 is a read timeout */
+                xxscreen(SCR_PT,'T',(long)winlo,"");
+	    } else {
+                xxscreen(SCR_PT,'T',(long)pktnum,"");
+            }
 	    logpkt('r',-1,(CHAR *)"<timeout>",0);
 	    if (flow == 1) ttoc(XON);	/* In case of Xoff blockage. */
 	    return('T');

--- a/ckcfn3.c
+++ b/ckcfn3.c
@@ -6,10 +6,11 @@
   Author: Frank da Cruz <fdc@columbia.edu>,
   Columbia University Academic Information Systems, New York City.
 
-  Copyright (C) 1985, 2010,
+  Copyright (C) 1985, 2022,
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
+    Last update: 8 May 2022
 */
 /*
  Note -- if you change this file, please amend the version number and date at
@@ -2179,10 +2180,11 @@ opena(f,zz) char *f; struct zattr *zz; {
     } else {				/* Did not open file OK. */
 
 	rf_err = ck_errstr();		/* Get system error message */
-	if (*rf_err)
-	  xxscreen(SCR_EM,0,0l,rf_err);
-	else
-	  xxscreen(SCR_EM,0,0l,"Can't open output file");
+	if (*rf_err) {
+            xxscreen(SCR_EM,0,0l,rf_err);
+        } else {
+            xxscreen(SCR_EM,0,0l,"Can't open output file");
+        }
         tlog(F110,"Failure to open",f,0L);
         tlog(F110,"Error:",rf_err,0L);
 	debug(F110,"opena error",rf_err,0);

--- a/ckcfns.c
+++ b/ckcfns.c
@@ -11,10 +11,11 @@ char *nm[] =  { "Disabled", "Local only", "Remote only", "Enabled" };
   Columbia University Academic Information Systems, New York City (1974-2011)
   The Kermit Project, Bronx NY (2011-????)
 
-  Copyright (C) 1985, 2021,
+  Copyright (C) 1985, 2022,
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
+    Last update: Thu May  5 15:22:36 2022
 */
 /*
  System-dependent primitives defined in:
@@ -3362,7 +3363,7 @@ sipkt(c) char c;
 	debug(F101,"sipkt getsbuf","",k);
     }
     rp = rpar();			/* Get protocol parameters. */
-    debug(F110,"sipkt rp","",rp);     /* "rp" (number), not rpar (function) */
+    debug(F110,"sipkt rp",rp,0);        /* last 2 args fixed 2022-05-05 */
     if (!rp) rp = (CHAR *)"";
     x = spack(c,pktnum,(int)strlen((char *)rp),rp); /* Send them. */
     return(x);

--- a/ckcftp.c
+++ b/ckcftp.c
@@ -2,7 +2,7 @@
 
 /*  C K C F T P  --  FTP Client for C-Kermit  */
 
-char *ckftpv = "FTP Client, 9.0.265, 5 Nov 2021";
+char *ckftpv = "FTP Client, 9.0.266, 8 May 2022";
 
 /*
   Authors:
@@ -11,7 +11,7 @@ char *ckftpv = "FTP Client, 9.0.265, 5 Nov 2021";
     Frank da Cruz <fdc@columbia.edu>,
       The Kermit Project, Columbia University.
 
-  Copyright (C) 2000, 2021
+  Copyright (C) 2000, 2022
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
@@ -4470,14 +4470,19 @@ putfile(cx,
 #ifdef TLOG
     if (tralog) {
         if (rc > 0) {
-            if (rc == SKP_XNX)
+          switch (rc) {
+            case SKP_XNX:
               tlog(F100," /simulate: WOULD BE SENT:","no remote file",0);
-            else if (rc == SKP_XUP)
+              break;
+            case SKP_XUP:
               tlog(F100," /simulate: WOULD BE SENT:","remote file older",0);
-            else if (rc == SKP_SIM)
+              break;
+            case SKP_SIM:
               tlog(F100," /simulate: WOULD BE SENT","",0);
-            else
+              break;
+            default:
               tlog(F110," skipped:",gskreason(rc),0);
+            }
         } else if (rc == 0) {
             tlog(F101," complete, size", "", fsize);
         } else if (cancelfile) {
@@ -11200,11 +11205,12 @@ getreply(expecteof,lcs,rcs,vbm,fc) int expecteof, lcs, rcs, vbm, fc; {
             return(getreply(expecteof,lcs,rcs,vbm,auth));
         }
         ibuf[0] = obuf[i] = '\0';
-        if (ftpcode && n == '6')
-          if (ftpcode != 631 && ftpcode != 632 && ftpcode != 633) {
-              printf("Unknown reply: %d %s\n", ftpcode, obuf);
-              n = '5';
-          } else safe = (ftpcode == 631);
+        if (ftpcode && n == '6') {
+            if (ftpcode != 631 && ftpcode != 632 && ftpcode != 633) {
+                printf("Unknown reply: %d %s\n", ftpcode, obuf);
+                n = '5';
+            } else safe = (ftpcode == 631);
+        }
         if (obuf[0]                     /* if there is a string to decode */
 #ifdef CK_SSL
             && !ssl_ftp_active_flag     /* and not SSL/TLS */

--- a/ckcmai.c
+++ b/ckcmai.c
@@ -1,8 +1,8 @@
 /* ckcmai.c - Main program for C-Kermit plus some miscellaneous functions */
 
-#define EDITDATE  "24 Jan 2022"         /* Last edit date dd mmm yyyy */
-#define EDITNDATE "20220124"		/* Keep them in sync */
-/* Mon Jan 24 16:04:13 2022 */
+#define EDITDATE  "16 May 2022"         /* Last edit date dd mmm yyyy */
+#define EDITNDATE "20220516"		/* Keep them in sync */
+/* Mon May 16 11:30:03 2022 */
 
 /*
 FOR A NEW VERSION (development, alpha, beta, release candidate formal release):
@@ -56,8 +56,8 @@ char * ck_cryear = "2022"; 		/* C-Kermit copyright year */
 */
 #ifndef BETATEST
 #ifndef OS2                             /* UNIX, VMS, etc... (i.e. C-Kermit) */
-char *ck_s_test = "Alpha";		/* "Dev","Alpha","Beta","RC", or "" */
-char *ck_s_tver = "07";			/* Test version number */
+char *ck_s_test = "Beta";		/* "Dev","Alpha","Beta","RC", or "" */
+char *ck_s_tver = "01";			/* Test version number */
 #else  /* OS2 */
 char *ck_s_test = "";			/* (i.e. K95) */
 char *ck_s_tver = "";
@@ -80,10 +80,13 @@ char *ck_s_date = EDITDATE;		/* See top */
 char *buildid = EDITNDATE;		/* See top */
 
 #ifdef UNIX
-static char sccsid[] = "@(#)C-Kermit 9.0.305";
+static char sccsid[] = "@(#)C-Kermit 10.0";
 #endif /* UNIX */
 
 /*
+  As of C-Kermit 10.0, we no longer use major.minor.edit version number,
+  just major.minor.
+
   The C-Kermit Version number is major.minor.edit (integers).
   Major version always goes up.
 
@@ -98,8 +101,8 @@ static char sccsid[] = "@(#)C-Kermit 9.0.305";
   for future releases.
 */
 
-char *ck_s_ver = "9.0.305";             /* C-Kermit version string */
-long  ck_l_ver =  900305L;              /* C-Kermit version number */
+char *ck_s_ver = "10.0";             /* C-Kermit version string */
+long  ck_l_ver = 1000000L;              /* C-Kermit version number */
 
 #ifdef OS2
 /* New Open Source C-Kermit for Windows is just C-Kermit */
@@ -168,17 +171,18 @@ int nolocale = 1;                       /* Don't use Locale */
 
 /*
   Principal Author: Frank da Cruz
-  fdc@kermitproject.org OR fdc@columbia.edu.
+    Columbia University 1974-2011;
+    the Open Source Kermit Project 2011-2022.
+    fdc@kermitproject.org OR fdc@columbia.edu.
 
   I am no longer at Columbia University as of 1 July 2011.
   The new Open Source Kermit Project website is the  definitive
   source for Kermit software created or updated since that date:
 
-    http://www.kermitproject.org
+    https://www.kermitproject.org
 
-  The associated FTP site is:
-
-    ftp://ftp.kermitproject.org/
+  The associated FTP site was ftp://ftp.kermitproject.org/ but FTP has been
+  "deprecated" since 2021 so all downloads are now done by HTTP(S) links.
 
   Note that Columbia University holds the copyright to this software in
   perpetuity, but as of C-Kermit 9.0 the license has changed from the

--- a/ckcpro.c
+++ b/ckcpro.c
@@ -7,7 +7,7 @@
 char *wartv = "Wart Version 2.15, 18 September 2020 ";
 
 char *protv =                                                     /* -*-C-*- */
-"C-Kermit Protocol Module 9.0.165, 17 December 2021";
+"C-Kermit Protocol Module 9.0.165, 8 May 2022";
 
 int kactive = 0;			/* Kermit protocol is active */
 
@@ -18,7 +18,7 @@ int kactive = 0;			/* Kermit protocol is active */
   Author: Frank da Cruz <fdc@columbia.edu>,
   Columbia University Academic Information Systems, New York City.
 
-  Copyright (C) 1985, 2014
+  Copyright (C) 1985, 2022
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
@@ -2513,17 +2513,19 @@ rcv_shortreply() {
 		RESUME;
 		return(-1);
 	    } else {
-		if (rdatap)		/* If we had data */
-		  if (*rdatap)		/* add a line terminator */
-		    if (remfile) {	/* to file */
-			zsoutl(ZOFILE,"");
-		    } else {		/* or to screen. */
+		if (rdatap) {		/* If we had data */
+                    if (*rdatap) {      /* add a line terminator */
+                        if (remfile) {  /* to file */
+                            zsoutl(ZOFILE,"");
+                        } else {        /* or to screen. */
 #ifndef NOICP
-			if (!query || !xcmdsrc)
+                            if (!query || !xcmdsrc)
 #endif /* NOICP */
-			  if (!(quiet && rcdactive))
-			    conoll("");
-		    }
+                              if (!(quiet && rcdactive))
+                                conoll("");
+                        }
+                    }
+                }
 		if (bye_active && network) { /* I sent BYE or REMOTE LOGOUT */
 		    msleep(500);	/* command and got the ACK... */
 		    bye_active = 0;

--- a/ckcpro.w
+++ b/ckcpro.w
@@ -1,5 +1,5 @@
 char *protv =                                                     /* -*-C-*- */
-"C-Kermit Protocol Module 9.0.165, 17 December 2021";
+"C-Kermit Protocol Module 9.0.165, 8 May 2022";
 
 int kactive = 0;			/* Kermit protocol is active */
 
@@ -10,7 +10,7 @@ int kactive = 0;			/* Kermit protocol is active */
   Author: Frank da Cruz <fdc@columbia.edu>,
   Columbia University Academic Information Systems, New York City.
 
-  Copyright (C) 1985, 2014
+  Copyright (C) 1985, 2022
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
@@ -2315,17 +2315,19 @@ rcv_shortreply() {
 		RESUME;
 		return(-1);
 	    } else {
-		if (rdatap)		/* If we had data */
-		  if (*rdatap)		/* add a line terminator */
-		    if (remfile) {	/* to file */
-			zsoutl(ZOFILE,"");
-		    } else {		/* or to screen. */
+		if (rdatap) {		/* If we had data */
+                    if (*rdatap) {      /* add a line terminator */
+                        if (remfile) {  /* to file */
+                            zsoutl(ZOFILE,"");
+                        } else {        /* or to screen. */
 #ifndef NOICP
-			if (!query || !xcmdsrc)
+                            if (!query || !xcmdsrc)
 #endif /* NOICP */
-			  if (!(quiet && rcdactive))
-			    conoll("");
-		    }
+                              if (!(quiet && rcdactive))
+                                conoll("");
+                        }
+                    }
+                }
 		if (bye_active && network) { /* I sent BYE or REMOTE LOGOUT */
 		    msleep(500);	/* command and got the ACK... */
 		    bye_active = 0;

--- a/ckctel.c
+++ b/ckctel.c
@@ -1,4 +1,4 @@
-char *cktelv = "Telnet support, 9.0.278, 21 Dec 2021";
+char *cktelv = "Telnet support, 9.0.279, 27 Jan 2022";
 #define CKCTEL_C
 
 int sstelnet = 0;                       /* Do server-side Telnet negotiation */
@@ -22,6 +22,7 @@ int sstelnet = 0;                       /* Do server-side Telnet negotiation */
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
+    Latest update: 27 Jan 2022
 */
 
 /*
@@ -4670,9 +4671,9 @@ tn_xdoop(z, echo, fn) CHAR z; int echo; int (*fn)();
               case TELOPT_NEWENVIRON:   /* SB NEW-ENVIRON SEND */
                 {
                   CHAR request[6];      /* request it */
-                  sprintf(request,"%cUSER",TEL_ENV_VAR);        /* safe */
-                  tn_ssbopt(TELOPT_NEWENVIRON,TELQUAL_SEND,request,
-                            strlen(request));
+                  sprintf(request,"%cUSER",TEL_ENV_VAR); /* safe */
+                  tn_ssbopt(TELOPT_NEWENVIRON,TELQUAL_SEND,(CHAR *)request,
+                            strlen((CHAR *)request)); /* 2022-01-27 */
                   TELOPT_UNANSWERED_SB(TELOPT_NEWENVIRON)=1;
                 }
                 break;

--- a/ckucmd.c
+++ b/ckucmd.c
@@ -1,6 +1,6 @@
 #include "ckcsym.h"
 
-char *cmdv = "Command package 9.0.176, 18 September 2020";
+char *cmdv = "Command package 9.0.178, 16 May 2022";
 
 /*  C K U C M D  --  Interactive command package for Unix  */
 
@@ -11,7 +11,7 @@ char *cmdv = "Command package 9.0.176, 18 September 2020";
   Formerly of Columbia University Academic Information Systems, New York City.
   Since 1 July 2011, Open Source Kermit Project.
 
-  Copyright (C) 1985, 2020,
+  Copyright (C) 1985, 2022,
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
@@ -3671,7 +3671,7 @@ cmkey2(table,n,xhlp,xdef,tok,f,pmsg)
 		else if (tl > 1)
 		  printf("or one of the tokens: %s\n",ckspread(tok));
 	    }
-	    printf("%s%s", cmprom, cmdbuf);
+	    printf("\n%s%s", cmprom, cmdbuf);
 	    fflush(stdout);
 	    break;
 
@@ -6799,7 +6799,8 @@ CMDIRPARSE:
 #endif /* USE_ARROWKEYS */
                              )
                      ) {		/* A real ESC was typed */
-		    int x;
+		    int x = 0;
+#ifndef NOARROWKEYS
 		    msleep(200);	/* Wait 1/5 sec */
 		    x = cmdconchk();	/* Was it followed by anything? */
 		    debug(F101,"Arrowkey ESC cmdconchk","",x);
@@ -6834,6 +6835,7 @@ CMDIRPARSE:
 			    }
 			}
 		    }
+#endif  /* NOARROWKEYS */
 		}
 
 		switch (c) {

--- a/ckutio.c
+++ b/ckutio.c
@@ -1,12 +1,12 @@
 #define CKUTIO_C
 
 #ifdef aegis
-char *ckxv = "Aegis Communications support, 9.0.331, 07 Nov 2021";
+char *ckxv = "Aegis Communications support, 9.0.333, 13 May 2022";
 #else
 #ifdef Plan9
-char *ckxv = "Plan 9 Communications support, 9.0.331, 07 Nov 2021";
+char *ckxv = "Plan 9 Communications support, 9.0.333, 13 May 2022";
 #else
-char *ckxv = "UNIX Communications support, 9.0.331, 07 Nov 2021";
+char *ckxv = "UNIX Communications support, 9.0.333, 13 May 2022";
 #endif /* Plan9 */
 #endif /* aegis */
 
@@ -18,7 +18,7 @@ char *ckxv = "UNIX Communications support, 9.0.331, 07 Nov 2021";
   Author: Frank da Cruz (fdc@columbia.edu),
   The Kermit Project, Bronx, NY.
 
-  Copyright (C) 1985, 2021,
+  Copyright (C) 1985, 2022,
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
@@ -7659,9 +7659,6 @@ ttsspd(cps) int cps; {
 #ifdef B921600
       case 92160: s = B921600; break;
 #endif /* B921600 */
-#ifdef B1500000
-      case 150000: s = B1500000; break;
-#endif /* B921600 */
 #endif /* HPUX */
       default:
 	ok = 0;				/* Good speed not found, so not ok */
@@ -7970,11 +7967,43 @@ ttspdlist() {
     debug(F101,"ttspdlist B921600","",B921600);
     spdlist[i++] = 921600L;
 #endif /* B921600 */
+
+/* The following are new in C-Kermit 10.0 */
+
+#ifdef B1000000
+    debug(F101,"ttspdlist B1000000","",B1000000);
+    spdlist[i++] = 1000000L;
+#endif /* B1000000 */
+#ifdef B1152000
+    debug(F101,"ttspdlist B1152000","",B1152000);
+    spdlist[i++] = 1152000L;
+#endif /* B1152000 */
 #ifdef B1500000
     debug(F101,"ttspdlist B1500000","",B1500000);
-   spdlist[i++] = 1500000L;
+    spdlist[i++] = 1500000L;
 #endif /* B1500000 */
+#ifdef B2000000
+    debug(F101,"ttspdlist B2000000","",B2000000);
+    spdlist[i++] = 2000000L;
+#endif /* B2000000 */
+#ifdef B2500000
+    debug(F101,"ttspdlist B2500000","",B2500000);
+    spdlist[i++] = 2500000L;
+#endif /* B2500000 */
+#ifdef B3000000
+    debug(F101,"ttspdlist B3000000","",B3000000);
+    spdlist[i++] = 3000000L;
+#endif /* B3000000 */
+#ifdef B3500000
+    debug(F101,"ttspdlist B3500000","",B3500000);
+    spdlist[i++] = 3500000L;
+#endif /* B3500000 */
+#ifdef B4000000
+    debug(F101,"ttspdlist B4000000","",B4000000);
+    spdlist[i++] = 4000000L;
+#endif /* B4000000 */
 #endif /* USETCSETSPEED */
+
     spdlist[0] = i - 1;			/* Return count in 0th element */
     debug(F111,"ttspdlist spdlist","0",spdlist[0]);
     return((long *)spdlist);
@@ -8240,9 +8269,32 @@ ttgspd() {				/* Get current serial device speed */
 #ifdef B921600
       case B921600: ss = 921600L; break;
 #endif /* B921600 */
+
+#ifdef B1000000
+      case B1000000: ss = 1000000L; break;
+#endif /* B1000000 */
+#ifdef B1152000
+      case B1152000: ss = 1152000L; break;
+#endif /* B1152000 */
 #ifdef B1500000
       case B1500000: ss = 1500000L; break;
 #endif /* B1500000 */
+#ifdef B2000000
+      case B2000000: ss = 2000000L; break;
+#endif /* B2000000 */
+#ifdef B2500000
+      case B2500000: ss = 2500000L; break;
+#endif /* B2500000 */
+#ifdef B3000000
+      case B3000000: ss = 3000000L; break;
+#endif /* B3000000 */
+#ifdef B3500000
+      case B3500000: ss = 3500000L; break;
+#endif /* B3500000 */
+#ifdef B4000000
+      case B4000000: ss = 4000000L; break;
+#endif /* B4000000 */
+
       default:
 	ss = -1; break;
     }
@@ -12895,11 +12947,14 @@ coninc(timo) int timo; {
   When this happens, we have to post the read() again.  This is apparently not
   a problem in BSD-based UNIX versions.
 */
-	    if (errno == EINTR)		/* Read interrupted. */
-	      if (conesc)  {		/* If by SIGQUIT, */
- 		 conesc = 0;		/* the conesc variable is set, */
- 		 return(escchr);	/* so return the escape character. */
-	     } else continue;		/* By other signal, try again. */
+	    if (errno == EINTR) {       /* Read interrupted. */
+                if (conesc)  {		/* If by SIGQUIT, */
+                    conesc = 0;		/* the conesc variable is set, */
+                    return(escchr);	/* so return the escape character. */
+                } else {
+                  continue;		/* By other signal, try again. */
+                }
+            }
 #else
 /*
   This might be dangerous, but let's do this on non-System V versions too,

--- a/ckuus2.c
+++ b/ckuus2.c
@@ -11,10 +11,11 @@
     Jeffrey E Altman <jaltman@secure-endpoints.com>
       Secure Endpoints Inc., New York City
 
-  Copyright (C) 1985, 2017,
+  Copyright (C) 1985, 2022,
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
+    Last update: 11 May 2022
 
   This module contains HELP command and other long text strings.
 
@@ -1450,6 +1451,19 @@ static char *hxxout[] = {
 " ",
 "Also see SET OUTPUT.",
 "" };
+
+static char *hxxcsn[] = {
+"Compact Substring Notation is a shorthand notation for the built-in",
+"\\fsubstring() function; 'name' is the name of any macro-type variable:",
+"  \\s(name[n:m])",
+"      Substring of \\m(name) starting at position n, length m",
+"  \\s(name[n_m])",
+"      Substring of \\m(name) from position n to position m",
+"  \\s(name[n]) or \\s(name[n:])",
+"      Substring of \\m(name) from position n to the end",
+"  \\s(name[n.])",
+"      The character at position n",
+""};
 #endif /* NOSPL */
 
 static char *hxypari[] = {
@@ -1766,6 +1780,8 @@ static char *hmxxgrep[] = {
 #endif /* UNIXOROSK */
 " ",
 "File selection options:",
+"  /ARRAY:&x",
+"    Returns the results in the specified array.",
 "  /NOBACKUPFILES",
 "    Excludes backup files (like oofa.txt.~3~) from the search.",
 "  /DOTFILES",
@@ -1910,7 +1926,9 @@ static char *hmxxtouch[] = {
 " ",
 " Action switches:",
 " ",
-"   /MODTIME:        Modification time for selected files.",
+"   /MODTIME:        Changes the modification time for the selected files.",
+"                     in numeric yyyy:mm:dd:hh:mm:ss format.",
+"                     if hh:mm:ss omitted time is set to 00:00:00",
 "   /SIMULATE        List files that would be touched, but don't touch them.",
 "   /LIST            Show which files are being touched.",
 #endif /* RECURSIVE */
@@ -5102,6 +5120,7 @@ static char *hxxxla[] = {
 " ",
 "  Multiple files can be translated if file2 is a directory or device name,",
 "  rather than a filename, or if file2 is omitted.  Note: CONVERT would",
+"  would be a better name for this command but it's too late now.",
 "" };
 #endif /* NOCSETS */
 
@@ -6087,7 +6106,7 @@ static char * hxxf_re[] = {
 "  empty, this indicates a NUL byte was read.",
 " ",
 "/TRIM",
-"  Tells Kermit to trim trailing whitespace when used with /LINE.  Ignored",
+"  Trims trailing whitespace from the right when used with /LINE.  Ignored",
 "  if used with /CHAR or /SIZE.",
 " ",
 "/UNTABIFY",
@@ -6235,7 +6254,10 @@ dohlp(xx) int xx; {
     int x,y;
 
     debug(F101,"DOHELP xx","",xx);
-    if (xx < 0) return(xx);
+    if (xx < 0) {
+        printf("Sorry, that is not a help topic\n");
+        return(-9);
+    };
 
 #ifdef NOHELP
     if ((x = cmcfm()) < 0)
@@ -7034,6 +7056,9 @@ Equivalent to GET /COMMAND; see HELP GET for details."));
 #endif /* PIPESEND */
 
 #ifndef NOSPL
+case XXCSN:                             /* Compact Substring Notation */
+  return(hmsga(hxxcsn));
+
 case XXFUNC:
 /*
   Tricky parsing.  We want to let them type the function name in any format
@@ -7454,9 +7479,11 @@ hmsga(s) char *s[]; {                   /* pausing at end of each screen. */
         for (j = 0; j < y; j++)         /* See how many newlines were */
           if (s[i][j] == '\n') k++;     /* in the string... */
         n += k;
-        if (n > (cmd_rows - 3) && *s[i+1]) /* After a screenful, give them */
-          if (!askmore()) return(0);    /* a "more?" prompt. */
-          else n = 0;
+        if (n > (cmd_rows - 3) && *s[i+1]) { /* After a screenful, give them */
+            if (!askmore()) {                /* a "more?" prompt. */
+                return(0);
+            } else { n = 0; }
+        }
     }
     printf("\n");
     return(0);
@@ -7480,7 +7507,7 @@ static char * supporttext[] = {
 " ",
 "  http://www.kermitproject.org/ckermit.html#doc",
 " ",
-"Z C-Kermit tutorial is here:",
+"A C-Kermit tutorial is here:",
 " ",
 "  http://www.kermitproject.org/ckututor.html",
 " ",
@@ -11198,7 +11225,7 @@ dohfunc(xx) int xx; {
 
 #ifdef RECURSIVE
       case FN_DIR:                      /* Recursive directory count */
-        printf("\\fdirectories(f1) - Directory list.\n\
+        printf("\\fdirectories(f1,&a) - Directory list.\n\
   f1 = directory specification, possibly containing wildcards.\n\
   &a = optional name of array to assign directory list to.\n");
         printf("Returns integer:\n\
@@ -11383,9 +11410,8 @@ Assign string words to an array.\n\
         break;
 
       case FN_TLOOK:
-        printf(
-"\\ftablelook(keyword,&a,[c]) - Lookup keyword in keyword table.\n\
-  pattern = String\n");
+        printf("\\ftablelook(keyword,&a,[c]) \
+- Lookup keyword in keyword table.\n");
         printf("  keyword = keyword to look up (can be abbreviated).\n");
         printf("  &a      = array designator, can include range specifier.\n");
         printf("            This array must be in alphabetical order.\n");
@@ -12049,8 +12075,9 @@ represent.\n");
  4. Platform-specific permissions string, e.g. drwxrwxr-x or RWED,RWE,RE,E\n\
  5. Platform-specific permissions code, e.g. an octal number like 40775\n\
  6. The file's size in bytes\n\
- 7. Type: 1=regular file; 2=executable; 3=directory; 4=link; 0=unknown.\n\
- 8. If link, the name of the file linked to.\n");
+ 7. Type: regular file, executable, directory, link, or unknown\n\
+ 8. If link, the name of the file linked to.\n\
+ 9. Transfer mode for file: text or binary\n");
         break;
 
       case FN_FILECMP:

--- a/ckuus3.c
+++ b/ckuus3.c
@@ -13,10 +13,11 @@
     Jeffrey E Altman <jaltman@secure-endpoints.com>
       Secure Endpoints Inc., New York City
 
-  Copyright (C) 1985, 2021,
+  Copyright (C) 1985, 2022,
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
+    Last update: 8 May 2022
 */
 
 /*  SET command (but much material has been split off into ckuus7.c). */
@@ -4106,7 +4107,7 @@ dosexp(s) char *s; {                    /* s = S-Expression */
             s2 = p[2];
             if (!s2) s2 = "";
             xx = strlen(s2);
-            if (xx = 0)                 /* Null or empty arg */
+            if (xx == 0)                /* Null or empty arg */
               goto xdosexp;
 
             /* Case 0 - number */
@@ -6159,75 +6160,75 @@ shomodem() {
         printf(" %c Dial-mode-string:     ", dialmstr ? ' ' : '*' );
         shods(dialmstr ? dialmstr : p->dmode_str);
         n = local ? 19 : 20;
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Dial-mode-prompt:     ", dialmprmt ? ' ' : '*' );
         shods(dialmprmt ? dialmprmt : p->dmode_prompt);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Dial-command:         ", dialcmd ? ' ' : '*' );
         shods(dialcmd ? dialcmd : p->dial_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Compression on:       ", dialdcon ? ' ' : '*' );
         if (!dialdcon)
           debug(F110,"dialdcon","(null)",0);
         else
           debug(F110,"dialdcon",dialdcon,0);
         shods(dialdcon ? dialdcon : p->dc_on_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Compression off:      ", dialdcoff ? ' ' : '*' );
         shods(dialdcoff ? dialdcoff : p->dc_off_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Error-correction on:  ", dialecon ? ' ' : '*' );
         shods(dialecon ? dialecon : p->ec_on_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Error-correction off: ", dialecoff ? ' ' : '*' );
         shods(dialecoff ? dialecoff : p->ec_off_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Autoanswer on:        ", dialaaon ? ' ' : '*' );
         shods(dialaaon ? dialaaon : p->aa_on_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Autoanswer off:       ", dialaaoff ? ' ' : '*' );
         shods(dialaaoff ? dialaaoff : p->aa_off_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 
         printf(" %c Speaker on:           ", dialspon ? ' ' : '*' );
         shods(dialspon ? dialspon : p->sp_on_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Speaker off:          ", dialspoff ? ' ' : '*' );
         shods(dialspoff ? dialspoff : p->sp_off_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Volume low:           ", dialvol1 ? ' ' : '*' );
         shods(dialvol1 ? dialvol1 : p->vol1_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Volume medium:        ", dialvol2 ? ' ' : '*' );
         shods(dialvol2 ? dialvol2 : p->vol2_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Volume high:          ", dialvol3 ? ' ' : '*' );
         shods(dialvol3 ? dialvol3 : p->vol3_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 
         printf(" %c Hangup-command:       ", dialhcmd ? ' ' : '*' );
         shods(dialhcmd ? dialhcmd : p->hup_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Hardware-flow:        ", dialhwfc ? ' ' : '*' );
         shods(dialhwfc ? dialhwfc : p->hwfc_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Software-flow:        ", dialswfc ? ' ' : '*' );
         shods(dialswfc ? dialswfc : p->swfc_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c No-flow-control:      ", dialnofc ? ' ' : '*' );
         shods(dialnofc ? dialnofc : p->nofc_str);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Pulse:                ", dialpulse ? ' ' : '*');
         shods(dialpulse ? dialpulse : p->pulse);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Tone:                 ", dialtone ? ' ' : '*');
         shods(dialtone ? dialtone : p->tone);
 
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Ignore-dialtone:      ", dialx3 ? ' ' : '*');
         shods(dialx3 ? dialx3 : p->ignoredt);
 
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         printf(" %c Predial-init:         ", dialini2 ? ' ' : '*');
         shods(dialini2 ? dialini2 : p->ini2);
 

--- a/ckuus4.c
+++ b/ckuus4.c
@@ -9,12 +9,12 @@
     Jeffrey E Altman <jaltman@secure-endpoints.com>
       Secure Endpoints Inc., New York City
 
-  Copyright (C) 1985, 2021,
+  Copyright (C) 1985, 2022,
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
     Last update:
-    Sat Nov  6 12:29:26 2021
+    Sun May  8 15:50:44 2022
 */
 
 /*
@@ -4776,17 +4776,17 @@ shotcp(n) int n; {
             else
               printf("no timeout\n");
         }
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* SO_LINGER */
 
 #ifdef SO_DONTROUTE
         printf(" DontRoute: %s\n", tcp_dontroute ? "on" : "off" );
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* SO_DONTROUTE */
 
 #ifdef TCP_NODELAY
         printf(" Nodelay: %s\n", showoff(tcp_nodelay));
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* TCP_NODELAY */
 
 #ifdef SO_SNDBUF
@@ -4794,14 +4794,14 @@ shotcp(n) int n; {
           printf(" Send buffer: (default size)\n");
         else
           printf(" Send buffer: %d bytes\n", tcp_sendbuf);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* SO_SNDBUF */
 #ifdef SO_RCVBUF
         if (tcp_recvbuf <= 0)
           printf(" Receive buffer: (default size)\n");
         else
           printf(" Receive buffer: %d bytes\n", tcp_recvbuf);
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* SO_RCVBUF */
 #endif /* SOL_SOCKET */
 #endif /* NOTCPOPTS */
@@ -5167,7 +5167,7 @@ shonet() {
         printf("\nNetwork directories:\n");
         for (i = 0; i < nnetdir; i++) {
             printf("%2d. %s\n",i,netdir[i]);
-            if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+            if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         }
     }
 #endif /* NODIAL */
@@ -5176,7 +5176,7 @@ shonet() {
     {
         extern char * sshcmd;
         printf("SSH COMMAND: %s\n",sshcmd ? sshcmd : "ssh -e none");
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     }
 #endif /* SSHCMD */
 
@@ -5185,7 +5185,7 @@ shonet() {
 #else
     printf("\nSupported networks:\n");
 #endif /* OS2 */
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 
 #ifdef VMS
 
@@ -5230,16 +5230,16 @@ shonet() {
 #endif /* WINTCP */
 #endif /* MULTINET */
 #endif /* TCPWARE */
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #ifdef TNCODE
     printf(", TELNET protocol\n\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     n = shotel(n);
     if (n < 0) return(0);
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* TNCODE */
     printf("\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf("\n");
     n = shotcp(++n);
     if (n < 0) return(0);
@@ -5247,22 +5247,22 @@ shonet() {
 
 #ifdef SUNX25
     printf(" SunLink X.25\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* SUNX25 */
 
 #ifdef STRATUSX25
     printf(" Stratus VOS X.25\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* STRATUSX25 */
 
 #ifdef IBMX25
     printf(" IBM AIX X.25\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* IBMX25 */
 
 #ifdef HPX25
     printf(" HP-UX X.25\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* HPX25 */
 
 #ifdef SSHBUILTIN
@@ -5279,23 +5279,23 @@ shonet() {
       printf(" DECnet, LAT and CTERM protocols\n");
     else
       printf(" DECnet, LAT and CTERM protocols - not available\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #else /* NT */
     if (dnet_avail)
       printf(" DECnet, LAT protocol\n");
     else
       printf(" DECnet, LAT protocol - not available\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* NT */
 #else
     printf(" DECnet\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* OS2 */
 #endif /* DECNET */
 
 #ifdef NPIPE
     printf(" Named Pipes\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* NPIPE */
 
 #ifdef CK_NETBIOS
@@ -5303,7 +5303,7 @@ shonet() {
       printf(" NETBIOS\n");
     else
       printf(" NETBIOS - not available\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* CK_NETBIOS */
 
 #ifdef SUPERLAT
@@ -5311,7 +5311,7 @@ shonet() {
       printf(" SuperLAT\n");
     else
       printf(" SuperLAT - not available\n") ;
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* SUPERLAT */
 
 #ifdef TCPSOCKET
@@ -5330,7 +5330,7 @@ shonet() {
 #else
             printf(" TCP/IP\n");
 #endif /* OS2ONLY */
-            if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+            if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         } else {
             int i = 1;
 #ifdef OS2ONLY
@@ -5338,11 +5338,11 @@ shonet() {
 #else
           printf(" TCP/IP [%16s]\n",ipaddr);
 #endif /* OS2ONLY */
-            if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+            if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 
             while (getlocalipaddrs(ipaddr,16,i++) >= 0) {
                 printf("        [%16s]\n",ipaddr);
-                if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+                if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
             }
         }
         if (nettype == NET_TCPB) {
@@ -5354,12 +5354,12 @@ shonet() {
             n = shotel(++n);
             if (n < 0) return(0);
 #endif /* TNCODE */
-            if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+            if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         }
 #ifdef OS2
     } else {
         printf(" TCP/IP - not available%s\n",tcpname[0] ? tcpname : "" );
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 #endif /* OS2 */
     }
 #endif /* TCPSOCKET */
@@ -5368,14 +5368,14 @@ shonet() {
     if (netbiosAvail && nettype == NET_BIOS) {
        printf("\n") ;
        if ((n = shonb(++n)) < 0) return(0);
-       if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+       if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     }
 #endif /* CK_NETBIOS */
 
 #endif /* VMS */
 
     printf("\nActive network connection:\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 
     if (network) {
         printf(" Host: %s",ttname);
@@ -5424,7 +5424,7 @@ shonet() {
     else if ( nettype == NET_DLL )
       printf("dynamic link library\n");
 #endif /* NETDLL */
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 
 #ifdef ANYX25
     if ((nettype == NET_SX25) ||
@@ -5436,7 +5436,7 @@ shonet() {
 #ifdef SSHBUILTIN
     if (nettype == NET_SSH) {
         printf("Secure Shell protocol\n");
-        if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+        if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     }
 #endif /* SSHBUILTIN */
 
@@ -5444,45 +5444,45 @@ shonet() {
 #ifdef RLOGCODE
         if (ttnproto == NP_RLOGIN) {
             printf(" LOGIN (rlogin) protocol\n");
-            if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+            if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         }
 #ifdef CK_KERBEROS
         else if (ttnproto == NP_K4LOGIN) {
             printf(" Kerberos 4 LOGIN (klogin) protocol\n");
-            if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+            if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         }
         else if (ttnproto == NP_EK4LOGIN) {
             printf(" Encrypted Kerberos 4 LOGIN (eklogin) protocol\n");
-            if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+            if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         }
         else if (ttnproto == NP_K5LOGIN) {
             printf(" Kerberos 5 LOGIN (klogin) protocol\n");
-            if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+            if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         }
         else if (ttnproto == NP_EK5LOGIN) {
             printf(" Encrypted Kerberos 5 LOGIN (eklogin) protocol\n");
-            if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+            if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         }
 #endif /* CK_KERBEROS */
 #endif /* RLOGCODE */
 #ifdef CK_KERBEROS
         if (ttnproto == NP_K5U2U) {
             printf(" Kerberos 5 User to User protocol\n");
-            if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+            if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         }
 #endif /* CK_KERBEROS */
 
 #ifdef TNCODE
         if (IS_TELNET()) {
             printf(" TELNET protocol\n");
-            if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+            if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
             printf(" Echoing is currently %s\n",duplex ? "local" : "remote");
-            if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+            if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         }
 #endif /* TNCODE */
         if (ttnproto == NP_TCPRAW) {
             printf(" Raw TCP socket\n");
-            if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+            if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
         }
     }
     printf("\n");
@@ -5546,17 +5546,17 @@ doshodial() {
     else if (dialmth == XYDM_P) printf("pulse  ");
     else if (dialmth == XYDM_T) printf("tone   ");
     printf("         Dial sort: %s\n",dialsrt ? "on" : "off");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(" Dial hangup:  %s             Dial display: %s\n",
            dialhng ? "on " : "off", dialdpy ? "on" : "off");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     if (dialrtr > 0) {
         printf(" Dial retries: %-12d    Dial interval: %d\n",
                dialrtr, dialint);
     } else {
         printf(" Dial retries: (auto)          Dial interval: %d\n", dialint);
     }
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(" Dial timeout: ");
 #ifdef CK_TAPI
     if (tttapi && !tapipass)
@@ -5568,20 +5568,20 @@ doshodial() {
     else
       printf("0 (auto)");
     printf("        Redial number: %s\n",dialnum ? dialnum : "(none)");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(" Dial confirmation: %s        Dial convert-directory: %s\n",
            dialcnf ? "on " : "off",
            dialcvt ? ((dialcvt == 1) ? "on" : "ask") : "off");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(" Dial ignore-dialtone: %s", dialidt ? "on " : "off");
     printf("     Dial pacing: %d\n",dialpace);
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(
 " Dial prefix:                  %s\n", dialnpr ? dialnpr : "(none)");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(
 " Dial suffix:                  %s\n", dialsfx ? dialsfx : "(none)");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(
 " Dial country-code:            %-12s", diallcc ? diallcc : "(none)");
     printf("Dial connect:  %s", dialcon ? ((dialcon == 1) ? "on" : "auto")
@@ -5591,14 +5591,14 @@ doshodial() {
     printf(
 "\n Dial area-code:               %-12s", diallac ? diallac : "(none)");
     n++;
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf("Dial restrict: ");
     if (dialrstr == 5) printf("international\n");
     else if (dialrstr == 4) printf("long-distance\n");
     else if (dialrstr == 2) printf("local\n");
     else if (dialrstr == 6) printf("none\n");
     else printf("?\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(" Dial lc-area-codes:           ");
     if (nlocalac == 0)
       printf("(none)");
@@ -5608,25 +5608,25 @@ doshodial() {
     printf(
 "\n Dial lc-prefix:               %s\n", diallcp ? diallcp : "(none)");
     n++;
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(
 " Dial lc-suffix:               %s\n", diallcs ? diallcs : "(none)");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(
 " Dial ld-prefix:               %s\n", dialldp ? dialldp : "(none)");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(
 " Dial ld-suffix:               %s\n", diallds ? diallds : "(none)");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(
 " Dial force-long-distance      %s\n", showoff(dialfld));
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(
 " Dial intl-prefix:             %s\n", dialixp ? dialixp : "(none)");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(
 " Dial intl-suffix:             %s\n", dialixs ? dialixs : "(none)");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(
 " Dial toll-free-area-code:     ");
     if (ntollfree == 0)
@@ -5635,7 +5635,7 @@ doshodial() {
       for (i = 0; i < ntollfree; i++)
         printf("%s ", dialtfc[i]);
     printf("\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 
     printf(
 " Dial pulse-countries:         ");
@@ -5645,7 +5645,7 @@ doshodial() {
       for (i = 0; i < ndialpucc; i++)
         printf("%s ", dialpucc[i]);
     printf("\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 
     printf(
 " Dial tone-countries:          ");
@@ -5655,14 +5655,14 @@ doshodial() {
       for (i = 0; i < ndialtocc; i++)
         printf("%s ", dialtocc[i]);
     printf("\n");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
 
     printf(
 	" Dial toll-free-prefix:        %s\n",
 	dialtfp ? dialtfp :
 	(dialldp ? dialldp : "(none)")
 	);
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(" Dial pbx-exchange:            ");
     if (ndialpxx == 0)
       printf("(none)");
@@ -5671,13 +5671,13 @@ doshodial() {
         printf("%s ", dialpxx[i]);
     printf("\n");
 
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(
 " Dial pbx-inside-prefix:       %s\n", dialpxi ? dialpxi : "(none)");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(
 " Dial pbx-outside-prefix:      %s\n", dialpxo ? dialpxo : "(none)");
-    if (++n > cmd_rows - 3) if (!askmore()) return(0); else n = 0;
+    if (++n > cmd_rows - 3) { if (!askmore()) return(0); else n = 0; }
     printf(
 " Dial macro:                   %s\n", dialmac ? dialmac : "(none)");
     return(0);

--- a/ckuus5.c
+++ b/ckuus5.c
@@ -14,8 +14,9 @@ int cmdsrc() { return(0); }
       The Kermit Project, New York City
     Jeffrey E Altman <jaltman@secure-endpoints.com>
       Secure Endpoints Inc., New York City
+    Last update: Mon May 16 12:31:56 2022
 
-  Copyright (C) 1985, 2021,
+  Copyright (C) 1985, 2022,
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
@@ -6869,10 +6870,10 @@ doshow(x) int x; {
           fnbuf[0] = NUL;
           if (!s) s = "";
           if (*s) ckstrncpy(fnbuf,s,100);
-      } else {
-          if ((y = cmcfm()) < 0)
-            return(y);
+      } else if ((y = cmcfm()) < 0) {
+          return(y);
       }
+
 #ifdef COMMENT
     /* This restriction is too general. */
 #ifdef IKSD
@@ -11148,6 +11149,9 @@ initoptlist() {
 #ifdef MINIX315
     makestr(&(optlist[noptlist++]),"MINIX315");
 #endif /* MINIX315 */
+#ifdef MINIX340
+     makestr(&(optlist[noptlist++]),"MINIX340"); /* 2020-02-01 TIH */
+#endif /* MINIX340 */
 #ifdef C70
     makestr(&(optlist[noptlist++]),"C70");
 #endif /* C70 */
@@ -12387,10 +12391,23 @@ shofea() {
     printf(" No built-in FTP client\n");
     if (++lines > cmd_rows - 3) { if (!askmore()) return(1); else lines = 0; }
 #endif /* NEWFTP */
+#ifdef NOTELNET
+    printf(" No built-in TELNET client\n");
+    if (++lines > cmd_rows - 3) { if (!askmore()) return(1); else lines = 0; }
+#endif /* NOTELNET */
+#ifdef NORLOGIN
+    printf(" No built-in RLOGIN client\n");
+    if (++lines > cmd_rows - 3) { if (!askmore()) return(1); else lines = 0; }
+#endif /* NORLOGIN */
 #ifdef NOHTTP
     printf(" No built-in HTTP client\n");
     if (++lines > cmd_rows - 3) { if (!askmore()) return(1); else lines = 0; }
 #endif /* NOHTTP */
+#ifdef NOARROWKEYS
+    printf(" No arrow-key support\n");
+    if (++lines > cmd_rows - 3) { if (!askmore()) return(1); else lines = 0; }
+#endif /* NOARROWKEYS */
+
 
 #ifdef NODIAL
     printf(" No DIAL command\n");

--- a/ckuus6.c
+++ b/ckuus6.c
@@ -8,13 +8,13 @@
     Jeffrey E Altman <jaltman@secure-endpoints.com>
       Secure Endpoints Inc., New York City
 
-  Copyright (C) 1985, 2021,
+  Copyright (C) 1985, 2022,
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
 
   Last update:
-    Sat Nov  6 13:36:59 2021
+    Sun May  8 16:02:07 2022
 */
 
 /* Includes */
@@ -3410,10 +3410,11 @@ Disabling flow control temporarily %s...\n",
   dialfin:
 
     if (cx != XXLOOK) {
-        if (!success)
-          bleep((short) BP_FAIL);
-        else if (!quiet)
-          bleep((short) BP_NOTE);
+        if (!success) {
+            bleep((short) BP_FAIL);
+        } else if (!quiet) {
+            bleep((short) BP_NOTE);
+        }
 #ifdef OS2
         setint();                       /* Fix OS/2 interrupts */
 #endif /* OS2 */

--- a/ckuus7.c
+++ b/ckuus7.c
@@ -9,10 +9,11 @@
     Jeffrey E Altman <jaltman@secure-endpoints.com>
       Secure Endpoints Inc., New York City
 
-  Copyright (C) 1985, 2020,
+  Copyright (C) 1985, 2022,
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
+    Last update: 12 May 2022
 */
 
 /*
@@ -330,7 +331,10 @@ static struct keytab shtab[] = {        /* SET HOST command options */
     { "/pty",          SL_PTY,    0 },
 #endif /* NETPTY */
     { "/server",       SL_SRV,    0 },
+#ifdef COMMENT
+/* The code implementing this was never written */
     { "/timeout",      SL_TMO,    CM_ARG },
+#endif  /* COMMENT */
     { "/userid",       SL_UID,    CM_ARG },
     { "/wait",         SL_WAIT,   0 },
     { "", 0, 0 }
@@ -3012,8 +3016,9 @@ dopurge() {                             /* Do the PURGE command */
                                minsize,maxsize,0,8,pxlist) < 1) {
             if (listing > 0) {
                 printf(" %s (SKIPPED)\n",namebuf);
-                if (++lines > cmd_rows - 3)
-                  if (!askmore()) goto xpurge; else lines = 0;
+                if (++lines > cmd_rows - 3) {
+                    if (!askmore()) goto xpurge; else lines = 0;
+                }
             }
             continue;
         }

--- a/ckuusr.h
+++ b/ckuusr.h
@@ -4,10 +4,11 @@
   Author: Frank da Cruz <fdc@columbia.edu>,
   Columbia University Academic Information Systems, New York City.
 
-  Copyright (C) 1985, 2017,
+  Copyright (C) 1985, 2022,
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
+    Last update: Thu May 12 12:36:22 2022
 */
 #ifndef CKUUSR_H
 #define CKUUSR_H
@@ -778,6 +779,7 @@ struct stringint {			/* String and (wide) integer */
 #define XXPUTE  268     /* PUTENV */
 #define XXXMSG  269     /* XMESSAGE */
 #define XXCHG   270     /* CHANGE */
+#define XXCSN   271     /* COMPACT-SUBSTRING */
 
 /* End of Top-Level Commands */
 

--- a/ckuusx.c
+++ b/ckuusx.c
@@ -9,10 +9,11 @@
     Jeffrey E Altman <jaltman@secure-endpoints.com>
       Secure Endpoints Inc., New York City
 
-  Copyright (C) 1985, 2021,
+  Copyright (C) 1985, 2022,
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
+    Last update: 8 May 2022
 */
 
 /*
@@ -980,6 +981,7 @@ _PROTOTYP( char * strerror, (int) );
     if (ckrooterr)
       return("Off limits");
 #endif /* CKROOT */
+    debug(F101,"ck_errstr errno","",errno);
     return(strerror(errno));
 #else  /* !USE_STRERROR */
 #ifdef VMS
@@ -1734,7 +1736,7 @@ scanfile(name,flag,nscanfile) char * name; int * flag, nscanfile; {
 			if (c != ESC && c != SO && c != SI)
 			  c0noniso++;
 		    }
-		    if ((c == '\032')	/* Ctrl-Z */
+		    if (c == '\032'	/* Ctrl-Z */
 #ifdef COMMENT
 			&& eof && (i >= count - 2)
 #endif /* COMMENT */
@@ -2093,8 +2095,7 @@ scanstring(s) char * s; {
 		    if (c != ESC && c != SO && c != SI)
 		      c0noniso++;
 		}
-		if ((c == '\032')	/* Ctrl-Z */
-		    ) {
+		if (c == '\032') {	/* Ctrl-Z */
 		    c0controls--;
 		    c0noniso--;
 		}
@@ -3825,11 +3826,11 @@ chkint() {
         xxscreen(SCR_QE,0,(long)lscapu," locking shifts");
         if (!network)
           xxscreen(SCR_QE,0, speed, " speed");
-        if (what & W_SEND)
-
-          xxscreen(SCR_QE,0,spsiz, " packet length");
-        else if (what & W_RECV || what & W_REMO)
-          xxscreen(SCR_QE,0,urpsiz," packet length");
+        if (what & W_SEND) {
+            xxscreen(SCR_QE,0,spsiz, " packet length");
+        } else if (what & W_RECV || what & W_REMO) {
+            xxscreen(SCR_QE,0,urpsiz," packet length");
+        }
         xxscreen(SCR_QE,0,wslots,  " window slots");
         fdispla = ofd; /* [MF] Restore file display type */
         return(0);
@@ -6378,7 +6379,7 @@ int
 #ifdef CK_ANSIC
 ck_curpos(int row, col)
 #else
-ck_curpos(row, col) int row, col;
+ck_curpos(row, col) int row, int col;
 #endif  /* CK_ANSIC */
  {
     move(row, col);
@@ -9168,7 +9169,14 @@ char *s;        /* a string */
 #ifndef CK_CURPOS
 /* Dummies for when cursor control is not supported */
 int
-ck_curpos(row, col) {
+#ifdef CK_ANSIC
+# fdc 5 May 2022
+ck_curpos(int row, col) {
+#else
+ck_curpos(row, col)
+    int row;
+    int col;
+#endif  /* CK_ANSIC */
     return(-1);
 }
 

--- a/ckuver.h
+++ b/ckuver.h
@@ -2,7 +2,7 @@
 /*
   Author: Frank da Cruz <fdc@kermitproject.edu>.
 
-  Copyright (C) 1985, 2012,
+  Copyright (C) 1985, 2022,
     Trustees of Columbia University in the City of New York.
     All rights reserved.  See the C-Kermit COPYING.TXT file or the
     copyright text in the ckcmai.c module for disclaimer and permissions.
@@ -504,6 +504,12 @@
 #endif /* HPUX   */
 
 #ifndef MINIX
+#ifdef MINIX340
+#define MINIX
+#endif /* MINIX340 */
+#endif /* MINIX */
+
+#ifndef MINIX
 #ifdef MINIX315
 #define MINIX
 #endif	/* MINIX315 */
@@ -516,6 +522,12 @@
 #endif	/* MINIX */
 
 #ifdef MINIX
+#ifdef MINIX340
+#define HERALD " Minix 3.4.0"
+#ifndef MINIX3
+#define MINIX3
+#endif /* MINIX3 */
+#endif /* MINIX340 */
 #ifdef MINIX315
 #define HERALD " Minix 3.1.5"
 #ifndef MINIX3


### PR DESCRIPTION
For greater detail see https://www.kermitproject.org/ckupdates.html .

C-Kermit 10.0 Beta.01 16 May 2022

Alpha.07 in its basic configuration (e.g. no Kerberos or SSL support) seems
to have been OK on every platform tested, aside from the ever-increasing
assortment of picky-compiler warnings.  So after some polishing-up and a
major version-number promotion, we have the first Beta test.

C-Kermit 10.0 Beta.01 changes since Alpha.07

   Aside from the new version number, the changes since Alpha.07 are
   modest.

|> New features

     * Serial-port speed selections for 1000000, 2000000, 2500000,
       3000000, 3500000, and 4000000 bps, suggested by Pali Roh�r. The new
       high speeds have not been tested because I no longer have a
       computer with serial port.
     * New VDIRECTORY command with 1-letter synonym V, a convenient alias
       for the DIRECTORY command (and a familiar one to old DEC-20 hands).
     * New HELP COMPACT-SUBSTRING command to show the syntax for the
       compact substring notation that was added in C-Kermit 9.0.300.
     * HELP text improved for GREP, TRANSLATE, TOUCH /MODTIME, FREAD
       /TRIM, FUNCTION DIRECTORIES, FUNCTION FILEINFO.
     * New -DNODEPRECATED parameter for makefile KFLAGS to disinclude FTP,
       Telnet, and RLOGIN clients plus WTMP logging, all "deprecated" now.
       This saves only about 200K in the executable size.
     * New Makefile targets: New "list" target to list all targets and
       "count" target to show how many targets there are.

|> Bugs fixed

     * ckufio.c: Bug fixed affecting -DNOUUCP builds (such as Mac OS) when
       receiving a file in which C-Kermit created a bogus empty backup
       file (e.g. bug.txt.~1~). Reported and diagnosed by MacPorts port
       maintainer Lin Dongyu.
     * ckcfns.c, ckcfn2.c, ckcfn3.c, ckcpro.w: SET SEND PACKET-LENGTH
       applied to all packets when it should have applied only to Data
       packets, now it does [28]details here.
     * ckuus3.c: Bug fixed in S-Expression parser; "if (xx = 0)" should
       have been "if (xx == 0)" (did you know that C-Kermit had a
       [29]mini-LISP iterpreter built in?...  [30]What day is Easter in
       2033?)
     * ckcfns.c: The 'debug(F110,"sipkt rp","",rp);' statement in sipkt()
       had a bad argument list all these years.
     * Extraneous line in "help function tablelook" removed.
     * SET HOST command switch /TIMEOUT: was removed because the
       supporting code was never written.
     * Top-level DEBUG command that was added in C-Kermit 9.0 was removed
       because it never did anything and there was no help text for it.

|> Compiler warnings hushed

   ... most of them issued only by the very picky Mac OS Clang compiler:
     * ckcftp.c: changed a long if-else-if.. (dangling else) sequence to a
       switch
     * ckctel.c: changed:
tn_ssbopt(TELOPT_NEWENVIRON,TELQUAL_SEND,request,
        strlen(request));

           to:
tn_ssbopt(TELOPT_NEWENVIRON,TELQUAL_SEND,(CHAR *)request,
        strlen((CHAR *)request)); /* 2022-01-27 */

       in hopes of silencing some "Pointers are not assignment-compatible"
       and "Argument #1 is not the correct type" warnings on a platform I
       don't have access to (HP-UX).

     * ckcpro.w: fixed 1 dangling else
     * ckuusr.c: fixed 7 dangling elses
     * ckuus2.c: fixed 1 dangling else
     * ckuus3.c: fixed 10 dangling elses
     * ckuus4.c: fixed 67 dangling elses
     * ckuus5.c: fixed 1 dangling else
     * ckuus6.c: fixed 1 dangling else
     * ckuus7.c: fixed 1 dangling else
     * ckuusx.c: Fixed several dummy ck_curpos() declarations to suppress
       warnings.
     * ckuusx.c: fixed 2 extraneous parentheses and 1 dangling else
     * ckcfn2.c: fixed 1 dangling else
     * ckutio.c: fixed 1 dangling else
     * makefile: added -Wdeprecated-declarations to macos target (for
       logwtmp)

   "Dangling else" is (or was) perfectly legal when used correctly; the C
   language was originally designed for use by people who knew what they
   were doing and was thoroughly documented by its authors, Kernighan and
   Plauger, in a book (two really: original C and ANSI C). It makes no
   sense to keep changing this or any other programming language out from
   under all the millions of programs that have already been written in
   it.