### PR TITLE
Disable auto transfer mode by default

### DIFF
--- a/ckcftp.c
+++ b/ckcftp.c
@@ -951,7 +951,7 @@ int ftp_log = 1;                        /* FTP Auto-login */
 int sav_log = -1;
 int ftp_action = 0;                     /* FTP action from command line */
 int ftp_dates = 1;                      /* Set file dates from server */
-int ftp_xfermode = XMODE_A;		/* FTP-specific transfer mode */
+int ftp_xfermode = XMODE_M;		/* FTP-specific transfer mode */
 
 char ftp_reply_str[FTP_BUFSIZ] = "";    /* Last line of previous reply */
 char ftp_srvtyp[SRVNAMLEN] = { NUL, NUL }; /* Server's system type */

--- a/ckcmai.c
+++ b/ckcmai.c
@@ -1408,7 +1408,7 @@ int deblog = 0,                         /* Debug log is open */
     cursor_save = -1,                   /* Cursor state */
 #endif /* OS2 */
 
-    xfermode = XMODE_A,                 /* Transfer mode, manual or auto */
+    xfermode = XMODE_M,                 /* Transfer mode, manual or auto */
     xfiletype = -1,                     /* Transfer only text (or binary) */
     recursive = 0,                      /* Recursive directory traversal */
     nolinks   = 2,                      /* Don't follow symbolic links */


### PR DESCRIPTION
Prior to this change, "show file" shows, among other things:

 Transfer mode:           automatic
 File patterns:           automatic (SHOW PATTERNS for list)
 Default file type:       binary

With this change:

 Transfer mode:           manual
 File patterns:           automatic (but disabled by TRANSFER-MODE MANUAL)
 File type:               binary

The modern assumption is a byte-accurate transfer of files.  We have had a proliferation of file types, extensions, and complicating circumstances since the earlier days of Kermit.

By changing this default, we disable the heuristic for attempting to guess the type of files, and convert the existing binary default into a binary setting.

This can always be changed by the user, but the idea is to not violate the principle of least surprise.  If the user asks to transfer a file, we assume the user wants an exact transfer of the file unless stated otherwise.

Additionally, some platforms (eg, HP48 calculators) have wildly different behavior depending on whether a text or binary transfer is requested.  By defaulting to manual mode, the user is in charge and further surprises that may be caused by "set file type" being ignored can be avoided.